### PR TITLE
Centralize audio and add overlays

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,11 +1,14 @@
 "use client";
 import { Canvas, useThree } from '@react-three/fiber';
+import * as THREE from 'three';
 import { Physics } from '@react-three/cannon';
 import FloatingSphere from '@/components/FloatingSphere';
 import AudioVisualizer from '@/components/AudioVisualizer';
 import Floor from '@/components/Floor';
 import MusicalObject from '@/components/MusicalObject';
 import SoundPortals from '@/components/SoundPortals';
+import SpawnMenu from '@/components/SpawnMenu';
+import EffectWorm from '@/components/EffectWorm';
 import { useEffect, useState } from 'react';
 import { startNote, stopNote } from '@/lib/audio';
 import { useObjects } from '@/store/useObjects';
@@ -18,8 +21,9 @@ const Home = () => {
   function CameraController({ fov }: { fov: number }) {
     const { camera } = useThree();
     useEffect(() => {
-      camera.fov = fov;
-      camera.updateProjectionMatrix();
+      const perspCam = camera as THREE.PerspectiveCamera;
+      perspCam.fov = fov;
+      perspCam.updateProjectionMatrix();
     }, [fov, camera]);
     return null;
   }
@@ -61,6 +65,8 @@ const Home = () => {
               position={obj.position}
             />
           ))}
+          {/* experimental effect worm */}
+          <EffectWorm id="worm" position={[0, 1, 0]} />
         </Physics>
         {/* floating demo sphere */}
         <FloatingSphere />
@@ -91,6 +97,9 @@ const Home = () => {
           onChange={(e) => setFov(parseFloat(e.target.value))}
         />
       </div>
+
+      {/* Spawn menu overlay */}
+      <SpawnMenu />
     </div>
   );
 };

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,17 +1,18 @@
 "use client";
-import { Canvas, useThree } from '@react-three/fiber';
-import * as THREE from 'three';
-import { Physics } from '@react-three/cannon';
-import FloatingSphere from '@/components/FloatingSphere';
-import AudioVisualizer from '@/components/AudioVisualizer';
-import Floor from '@/components/Floor';
-import MusicalObject from '@/components/MusicalObject';
-import SoundPortals from '@/components/SoundPortals';
-import SpawnMenu from '@/components/SpawnMenu';
-import EffectWorm from '@/components/EffectWorm';
-import { useEffect, useState } from 'react';
-import { startNote, stopNote } from '@/lib/audio';
-import { useObjects } from '@/store/useObjects';
+import { Canvas, useThree } from "@react-three/fiber";
+import * as THREE from "three";
+import { Physics } from "@react-three/cannon";
+import FloatingSphere from "@/components/FloatingSphere";
+import AudioVisualizer from "@/components/AudioVisualizer";
+import Floor from "@/components/Floor";
+import MusicalObject from "@/components/MusicalObject";
+import SoundPortals from "@/components/SoundPortals";
+import SpawnMenu from "@/components/SpawnMenu";
+import EffectWorm from "@/components/EffectWorm";
+import { useEffect, useState } from "react";
+import sliderStyles from "@/styles/slider.module.css";
+import { startNote, stopNote } from "@/lib/audio";
+import { useObjects } from "@/store/useObjects";
 
 const Home = () => {
   // dynamic camera field-of-view state
@@ -39,7 +40,7 @@ const Home = () => {
 
   const objects = useObjects((state) => state.objects);
   return (
-    <div style={{ height: '100vh', width: '100vw', position: 'relative' }}>
+    <div style={{ height: "100vh", width: "100vw", position: "relative" }}>
       <Canvas shadows camera={{ position: [0, 5, 10], fov }}>
         {/* camera controller updates */}
         <CameraController fov={fov} />
@@ -75,19 +76,8 @@ const Home = () => {
       </Canvas>
 
       {/* Zoom slider UI overlay */}
-      <div
-        style={{
-          position: 'absolute',
-          top: '1rem',
-          left: '50%',
-          transform: 'translateX(-50%)',
-          zIndex: 10,
-          background: 'rgba(20,20,30,0.7)',
-          padding: '0.5rem',
-          borderRadius: '4px',
-        }}
-      >
-        <label style={{ color: '#fff', marginRight: '0.5rem' }}>FOV:</label>
+      <div className={sliderStyles.sliderWrapper}>
+        <label style={{ color: "#fff", marginRight: "0.5rem" }}>FOV:</label>
         <input
           type="range"
           min={30}

--- a/src/components/FloatingSphere.tsx
+++ b/src/components/FloatingSphere.tsx
@@ -1,24 +1,17 @@
-import React, { useRef, useEffect } from 'react';
+import React, { useRef } from 'react';
 import { useFrame } from '@react-three/fiber';
 import { Sphere } from '@react-three/drei';
-import { startNote, stopNote } from '../lib/audio';
 import { Mesh } from 'three';
 
 const FloatingSphere = () => {
   const sphereRef = useRef<Mesh>(null!);
 
-  useFrame(() => {
+  useFrame(({ clock }) => {
     if (sphereRef.current) {
-      sphereRef.current.position.y = Math.sin(Date.now() * 0.001) * 1.5;
+      sphereRef.current.position.y = Math.sin(clock.getElapsedTime()) * 1.5;
     }
   });
 
-  useEffect(() => {
-    startNote();
-    return () => {
-      stopNote();
-    };
-  }, []);
 
   return (
     <>

--- a/src/components/PortalRing.tsx
+++ b/src/components/PortalRing.tsx
@@ -2,22 +2,10 @@
 import React, { useRef } from 'react'
 import { useFrame } from '@react-three/fiber'
 import { Float } from '@react-three/drei'
-import * as Tone from 'tone'
 import type { Mesh } from 'three'
 import { usePortalRing } from './usePortalRing'
+import { playNote } from '../lib/audio'
 
-// Shared Synth instance, lazy-initialized after first user interaction
-let synth: Tone.Synth | null = null
-async function getSynth() {
-  if (synth) return synth
-  await Tone.start()
-  synth = new Tone.Synth().toDestination()
-  // configure oscillator & envelope per global rules
-  synth.oscillator.type = 'sine'
-  synth.envelope.attack = 0.05
-  synth.envelope.release = 1
-  return synth
-}
 
 // Portal definitions: assign a musical note and color to each
 const portalConfigs: { note: string; color: string }[] = [
@@ -72,16 +60,13 @@ const Portal: React.FC<{
 const PortalRing: React.FC = () => {
   const { groupRef, getPosition } = usePortalRing(portalConfigs.length)
 
-  const total = portalConfigs.length
-
   // debounce click interval
   let lastClick = 0
   const handlePortalClick = async (note: string) => {
     const now = performance.now()
     if (now - lastClick < 50) return
     lastClick = now
-    const s = await getSynth()
-    s.triggerAttackRelease(note, '1n', Tone.now())
+    await playNote(note)
   }
 
   return (

--- a/src/components/SoundPortals.tsx
+++ b/src/components/SoundPortals.tsx
@@ -1,6 +1,5 @@
 // src/components/SoundPortals.tsx
 import React, { useState, useRef } from 'react'
-import { useFrame } from '@react-three/fiber'
 import { Float, useCursor } from '@react-three/drei'
 import { useObjects, ObjectType } from '../store/useObjects'
 import type { Mesh } from 'three'
@@ -21,9 +20,6 @@ const Portal: React.FC<{ cfg: typeof portalConfigs[0]; position: [number, number
   const meshRef = useRef<Mesh>(null!)
   const [hovered, setHovered] = useState(false)
   useCursor(hovered)
-  useFrame((_, delta) => {
-    meshRef.current.rotation.y += delta * 0.5
-  })
   return (
     <Float position={position} floatIntensity={1} speed={1.5} rotationIntensity={0.5}>
       <mesh
@@ -51,8 +47,6 @@ const Portal: React.FC<{ cfg: typeof portalConfigs[0]; position: [number, number
 // SoundPortals arranged in a ring
 const SoundPortals: React.FC = () => {
   const { groupRef, getPosition } = usePortalRing(portalConfigs.length)
-
-  const total = portalConfigs.length
   return (
     <group ref={groupRef}>
       {portalConfigs.map((cfg, idx) => {

--- a/src/styles/slider.module.css
+++ b/src/styles/slider.module.css
@@ -1,0 +1,10 @@
+.sliderWrapper {
+  position: absolute;
+  top: 1rem;
+  left: 50%;
+  transform: translateX(-50%);
+  z-index: 10;
+  background: rgba(20, 20, 30, 0.7);
+  padding: 0.5rem;
+  border-radius: 4px;
+}


### PR DESCRIPTION
## Summary
- centralize portal ring audio through shared `playNote`
- remove per-object rotation update in SoundPortals
- make floating sphere use clock time
- add `SpawnMenu` overlay and experimental `EffectWorm` to scene
- cast camera to PerspectiveCamera to fix build error
- remove duplicate intro note from `FloatingSphere`

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_684e562dd34c8326b5d2e6f28c43f93b