### PR TITLE
Fix overlay event capturing and add transparency

### DIFF
--- a/src/components/AudioVisualizer.tsx
+++ b/src/components/AudioVisualizer.tsx
@@ -55,7 +55,7 @@ const AudioVisualizer: React.FC = () => {
         far={100}
         position={[0, 0, 10]}
       />
-      <mesh>
+      <mesh raycast={() => null}>
         <planeGeometry args={[width, height]} />
         <shaderMaterial
           ref={materialRef}
@@ -98,11 +98,12 @@ const AudioVisualizer: React.FC = () => {
               vec3 col=hsl2rgb(vec3(0.5,1.0,low));
               col+=hsl2rgb(vec3(0.666,1.0,mid));
               col+=hsl2rgb(vec3(0.833,1.0,high));
-              gl_FragColor=vec4(col,1.0);
+              gl_FragColor=vec4(col,0.5);
             }
           `}
           depthTest={false}
           depthWrite={false}
+          transparent
         />
       </mesh>
     </>


### PR DESCRIPTION
## Summary
- add `raycast={() => null}` to AudioVisualizer mesh so it doesn't intercept pointer events
- make the shader material transparent and set fragment alpha to 0.5
- run `npm run build && npm start` to verify the app builds and serves correctly

## Testing
- `npm run build`
- `npm start`


------
https://chatgpt.com/codex/tasks/task_e_684f21ff65a0832692fe78303a53b093