### PR TITLE
Add client-only scene wrapper

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,65 +1,21 @@
 "use client";
-import { Canvas, useThree, useFrame } from "@react-three/fiber";
-import { Physics } from "@react-three/cannon";
-import * as THREE from "three";
-import FloatingSphere from "@/components/FloatingSphere";
-import AudioVisualizer from "@/components/AudioVisualizer";
-import Floor from "@/components/Floor";
-import MusicalObject from "@/components/MusicalObject";
-import SoundPortals from "@/components/SoundPortals";
-import SpawnMenu from "@/components/SpawnMenu";
-import EffectWorm from "@/components/EffectWorm";
-import { useEffect, useState } from "react";
+import dynamic from "next/dynamic";
+import { useState } from "react";
 import sliderStyles from "@/styles/slider.module.css";
-import { startNote, stopNote } from "@/lib/audio";
-import { initPhysics } from "@/lib/physics";
+
+const SceneCanvas = dynamic(() => import("@/components/SceneCanvas"), {
+  ssr: false,
+});
 
 const Home = () => {
   const [fov, setFov] = useState(50);
 
-  function CameraController({ fov }: { fov: number }) {
-    const { camera } = useThree();
-    useEffect(() => {
-      const perspCam = camera as THREE.PerspectiveCamera;
-      perspCam.fov = fov;
-      perspCam.updateProjectionMatrix();
-    }, [fov, camera]);
-    return null;
-  }
-
-  useEffect(() => {
-    initPhysics();
-    startNote();
-    const timer = setTimeout(() => {
-      stopNote();
-    }, 2000);
-    return () => clearTimeout(timer);
-  }, []);
-
   return (
-    <div style={{ height: "100vh", width: "100vw", position: "relative" }}>
-      <Canvas shadows camera={{ position: [0, 5, 10], fov }}>
-        <Physics>
-          <CameraController fov={fov} />
-          <ambientLight intensity={0.3} />
-          <directionalLight
-            castShadow
-            position={[5, 10, 5]}
-            intensity={0.8}
-            shadow-mapSize-width={1024}
-            shadow-mapSize-height={1024}
-          />
-          <AudioVisualizer />
-          <Floor />
-          <MusicalObject />
-          <EffectWorm id="worm" position={[0, 1, 0]} />
-          <FloatingSphere />
-          <SoundPortals />
-        </Physics>
-      </Canvas>
+    <div style={{ height: '100vh', width: '100vw', position: 'relative' }}>
+      <SceneCanvas fov={fov} />
 
       <div className={sliderStyles.sliderWrapper}>
-        <label style={{ color: "#fff", marginRight: "0.5rem" }}>FOV:</label>
+        <label style={{ color: '#fff', marginRight: '0.5rem' }}>FOV:</label>
         <input
           type="range"
           min={30}
@@ -69,8 +25,6 @@ const Home = () => {
           onChange={(e) => setFov(parseFloat(e.target.value))}
         />
       </div>
-
-      <SpawnMenu />
     </div>
   );
 };

--- a/src/components/SceneCanvas.tsx
+++ b/src/components/SceneCanvas.tsx
@@ -1,0 +1,62 @@
+'use client'
+import React, { useEffect } from 'react'
+import { Canvas, useThree } from '@react-three/fiber'
+import { Physics } from '@react-three/cannon'
+import * as THREE from 'three'
+import FloatingSphere from './FloatingSphere'
+import AudioVisualizer from './AudioVisualizer'
+import Floor from './Floor'
+import MusicalObject from './MusicalObject'
+import SoundPortals from './SoundPortals'
+import SpawnMenu from './SpawnMenu'
+import EffectWorm from './EffectWorm'
+import { startNote, stopNote } from '../lib/audio'
+import { initPhysics } from '../lib/physics'
+
+interface Props {
+  fov: number
+}
+
+function CameraController({ fov }: { fov: number }) {
+  const { camera } = useThree()
+  useEffect(() => {
+    const persp = camera as THREE.PerspectiveCamera
+    persp.fov = fov
+    persp.updateProjectionMatrix()
+  }, [fov, camera])
+  return null
+}
+
+const SceneCanvas: React.FC<Props> = ({ fov }) => {
+  useEffect(() => {
+    initPhysics()
+    startNote()
+    const timer = setTimeout(() => stopNote(), 2000)
+    return () => clearTimeout(timer)
+  }, [])
+
+  return (
+    <Canvas shadows camera={{ position: [0, 5, 10], fov }}>
+      <Physics>
+        <CameraController fov={fov} />
+        <ambientLight intensity={0.3} />
+        <directionalLight
+          castShadow
+          position={[5, 10, 5]}
+          intensity={0.8}
+          shadow-mapSize-width={1024}
+          shadow-mapSize-height={1024}
+        />
+        <AudioVisualizer />
+        <Floor />
+        <MusicalObject />
+        <EffectWorm id="worm" position={[0, 1, 0]} />
+        <FloatingSphere />
+        <SoundPortals />
+        <SpawnMenu />
+      </Physics>
+    </Canvas>
+  )
+}
+
+export default SceneCanvas


### PR DESCRIPTION
## Summary
- wrap Canvas-based scene in new `SceneCanvas` component
- use dynamic import to disable server-side rendering
- move `SpawnMenu` into the 3D scene

## Testing
- `npm install`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_684f75c074c0832698a132dbdb6e6b3e