### PR TITLE
Add spawn previews for newly spawned objects

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,7 @@ To get started with the project, follow these steps:
 - A 3D scene rendered with React Three Fiber.
 - A floating sphere that demonstrates basic animation.
 - Basic note generation using Tone.js, showcasing sound synthesis capabilities.
+- Spawn previews that briefly show new objects near the camera before they appear in the scene.
 
 ## Future Enhancements
 

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,65 +1,21 @@
 "use client";
-import { Canvas, useThree, useFrame } from "@react-three/fiber";
-import { Physics } from "@react-three/cannon";
-import * as THREE from "three";
-import FloatingSphere from "@/components/FloatingSphere";
-import AudioVisualizer from "@/components/AudioVisualizer";
-import Floor from "@/components/Floor";
-import MusicalObject from "@/components/MusicalObject";
-import SoundPortals from "@/components/SoundPortals";
-import SpawnMenu from "@/components/SpawnMenu";
-import EffectWorm from "@/components/EffectWorm";
-import { useEffect, useState } from "react";
+import dynamic from "next/dynamic";
+import { useState } from "react";
 import sliderStyles from "@/styles/slider.module.css";
-import { startNote, stopNote } from "@/lib/audio";
-import { initPhysics } from "@/lib/physics";
+
+const SceneCanvas = dynamic(() => import("@/components/SceneCanvas"), {
+  ssr: false,
+});
 
 const Home = () => {
   const [fov, setFov] = useState(50);
 
-  function CameraController({ fov }: { fov: number }) {
-    const { camera } = useThree();
-    useEffect(() => {
-      const perspCam = camera as THREE.PerspectiveCamera;
-      perspCam.fov = fov;
-      perspCam.updateProjectionMatrix();
-    }, [fov, camera]);
-    return null;
-  }
-
-  useEffect(() => {
-    initPhysics();
-    startNote();
-    const timer = setTimeout(() => {
-      stopNote();
-    }, 2000);
-    return () => clearTimeout(timer);
-  }, []);
-
   return (
-    <div style={{ height: "100vh", width: "100vw", position: "relative" }}>
-      <Canvas shadows camera={{ position: [0, 5, 10], fov }}>
-        <Physics>
-          <CameraController fov={fov} />
-          <ambientLight intensity={0.3} />
-          <directionalLight
-            castShadow
-            position={[5, 10, 5]}
-            intensity={0.8}
-            shadow-mapSize-width={1024}
-            shadow-mapSize-height={1024}
-          />
-          <AudioVisualizer />
-          <Floor />
-          <MusicalObject />
-          <EffectWorm id="worm" position={[0, 1, 0]} />
-          <FloatingSphere />
-          <SoundPortals />
-        </Physics>
-      </Canvas>
+    <div style={{ height: '100vh', width: '100vw', position: 'relative' }}>
+      <SceneCanvas fov={fov} />
 
       <div className={sliderStyles.sliderWrapper}>
-        <label style={{ color: "#fff", marginRight: "0.5rem" }}>FOV:</label>
+        <label style={{ color: '#fff', marginRight: '0.5rem' }}>FOV:</label>
         <input
           type="range"
           min={30}
@@ -69,8 +25,6 @@ const Home = () => {
           onChange={(e) => setFov(parseFloat(e.target.value))}
         />
       </div>
-
-      <SpawnMenu />
     </div>
   );
 };

--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -2,4 +2,4 @@
 /// <reference types="next/image-types/global" />
 
 // NOTE: This file should not be edited
-// see https://nextjs.org/docs/pages/api-reference/config/typescript for more information.
+// see https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/src/components/SceneCanvas.tsx
+++ b/src/components/SceneCanvas.tsx
@@ -1,0 +1,64 @@
+'use client'
+import React, { useEffect } from 'react'
+import { Canvas, useThree } from '@react-three/fiber'
+import { Physics } from '@react-three/cannon'
+import * as THREE from 'three'
+import FloatingSphere from './FloatingSphere'
+import AudioVisualizer from './AudioVisualizer'
+import Floor from './Floor'
+import MusicalObject from './MusicalObject'
+import SoundPortals from './SoundPortals'
+import SpawnMenu from './SpawnMenu'
+import SpawnPreviewList from './SpawnPreviewList'
+import EffectWorm from './EffectWorm'
+import { startNote, stopNote } from '../lib/audio'
+import { initPhysics } from '../lib/physics'
+
+interface Props {
+  fov: number
+}
+
+function CameraController({ fov }: { fov: number }) {
+  const { camera } = useThree()
+  useEffect(() => {
+    const persp = camera as THREE.PerspectiveCamera
+    persp.fov = fov
+    persp.updateProjectionMatrix()
+  }, [fov, camera])
+  return null
+}
+
+const SceneCanvas: React.FC<Props> = ({ fov }) => {
+  useEffect(() => {
+    initPhysics()
+    startNote()
+    const timer = setTimeout(() => stopNote(), 2000)
+    return () => clearTimeout(timer)
+  }, [])
+
+  return (
+    <Canvas shadows camera={{ position: [0, 5, 10], fov }}>
+      <Physics>
+        <CameraController fov={fov} />
+        <ambientLight intensity={0.3} />
+        <directionalLight
+          castShadow
+          position={[5, 10, 5]}
+          intensity={0.8}
+          shadow-mapSize-width={1024}
+          shadow-mapSize-height={1024}
+        />
+        <AudioVisualizer />
+        <Floor />
+        <MusicalObject />
+        <EffectWorm id="worm" position={[0, 1, 0]} />
+        <FloatingSphere />
+        <SoundPortals />
+        <SpawnMenu />
+      </Physics>
+      <SpawnPreviewList />
+    </Canvas>
+  )
+}
+
+export default SceneCanvas

--- a/src/components/SpawnPreview.tsx
+++ b/src/components/SpawnPreview.tsx
@@ -1,0 +1,69 @@
+import React, { useRef, useEffect } from 'react'
+import { useThree, useFrame } from '@react-three/fiber'
+import * as THREE from 'three'
+import { animate, useMotionValue } from 'framer-motion'
+import { ObjectType, objectConfigs } from '../config/objectTypes'
+import { getObjectMeter } from '../lib/audio'
+import * as Tone from 'tone'
+import ShapeFactory from './ShapeFactory'
+
+interface Props {
+  id: string
+  type: ObjectType
+  onComplete: () => void
+}
+
+const SpawnPreview: React.FC<Props> = ({ id, type, onComplete }) => {
+  const { camera } = useThree()
+  const groupRef = useRef<THREE.Group>(null!)
+  const matRef = useRef<THREE.MeshStandardMaterial>(null!)
+  const scale = useMotionValue(0)
+  const opacity = useMotionValue(1)
+  const meterRef = useRef<Tone.Meter | null>(null)
+
+  useEffect(() => {
+    meterRef.current = getObjectMeter(id)
+    const controls = animate(scale, 1, { duration: 0.3 })
+    const fade = animate(opacity, 0, {
+      duration: 0.5,
+      delay: 0.3,
+      onComplete,
+    })
+    return () => {
+      controls.stop()
+      fade.stop()
+    }
+  }, [id, onComplete, scale, opacity])
+
+  useFrame(() => {
+    const group = groupRef.current
+    const mat = matRef.current
+    if (!group || !mat) return
+    const dir = new THREE.Vector3(0, 0, -2).applyQuaternion(camera.quaternion)
+    group.position.copy(camera.position).add(dir)
+    group.quaternion.copy(camera.quaternion)
+    const baseScale = scale.get()
+    const meter = meterRef.current
+    let pulse = 1
+    if (meter) {
+      const raw = meter.getValue()
+      const level = Array.isArray(raw) ? raw[0] : raw
+      const intensity = objectConfigs[type].pulseIntensity || 0
+      pulse = 1 + level * intensity
+    }
+    group.scale.setScalar(baseScale * pulse)
+    mat.opacity = opacity.get()
+    mat.transparent = true
+  })
+
+  return (
+    <group ref={groupRef}>
+      <mesh>
+        <ShapeFactory type={type} />
+        <meshStandardMaterial ref={matRef} color={objectConfigs[type].color} />
+      </mesh>
+    </group>
+  )
+}
+
+export default SpawnPreview

--- a/src/components/SpawnPreviewList.tsx
+++ b/src/components/SpawnPreviewList.tsx
@@ -1,0 +1,18 @@
+import React from 'react'
+import { useSpawnPreviews } from '../store/useSpawnPreviews'
+import SpawnPreview from './SpawnPreview'
+
+const SpawnPreviewList: React.FC = () => {
+  const previews = useSpawnPreviews((s) => s.previews)
+  const remove = useSpawnPreviews((s) => s.remove)
+
+  return (
+    <>
+      {previews.map((p) => (
+        <SpawnPreview key={p.id} id={p.id} type={p.type} onComplete={() => remove(p.id)} />
+      ))}
+    </>
+  )
+}
+
+export default SpawnPreviewList

--- a/src/store/useObjects.ts
+++ b/src/store/useObjects.ts
@@ -1,6 +1,7 @@
 // src/store/useObjects.ts
 import { create } from 'zustand'
 import { addBody } from "../lib/physics"
+import { useSpawnPreviews } from './useSpawnPreviews'
 
 export type ObjectType = 'note' | 'chord' | 'beat' | 'loop'
 export interface MusicalObject {
@@ -27,6 +28,7 @@ export const useObjects = create<ObjectState>((set, get) => ({
       position: [0, 3, 0], // default spawn position
     }
     set({ objects: [...get().objects, newObj] });
+    useSpawnPreviews.getState().show(id, type)
     addBody(id, newObj.position)
     return id
   },

--- a/src/store/useSpawnPreviews.ts
+++ b/src/store/useSpawnPreviews.ts
@@ -1,0 +1,20 @@
+import { create } from 'zustand'
+import { ObjectType } from './useObjects'
+
+export interface PreviewItem {
+  id: string
+  type: ObjectType
+}
+
+interface PreviewState {
+  previews: PreviewItem[]
+  show: (id: string, type: ObjectType) => void
+  remove: (id: string) => void
+}
+
+export const useSpawnPreviews = create<PreviewState>((set) => ({
+  previews: [],
+  show: (id, type) => set((s) => ({ previews: [...s.previews, { id, type }] })),
+  remove: (id) =>
+    set((s) => ({ previews: s.previews.filter((p) => p.id !== id) })),
+}))

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,7 +1,11 @@
 {
   "compilerOptions": {
     "target": "es5",
-    "lib": ["dom", "dom.iterable", "esnext"],
+    "lib": [
+      "dom",
+      "dom.iterable",
+      "esnext"
+    ],
     "allowJs": true,
     "skipLibCheck": true,
     "strict": true,
@@ -16,9 +20,23 @@
     "incremental": true,
     "baseUrl": ".",
     "paths": {
-      "@/*": ["src/*"]
-    }
+      "@/*": [
+        "src/*"
+      ]
+    },
+    "plugins": [
+      {
+        "name": "next"
+      }
+    ]
   },
-  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx"],
-  "exclude": ["node_modules"]
+  "include": [
+    "**/*.ts",
+    "**/*.tsx",
+    "next-env.d.ts",
+    ".next/types/**/*.ts"
+  ],
+  "exclude": [
+    "node_modules"
+  ]
 }


### PR DESCRIPTION
## Summary
- integrate a spawn preview system for new objects
- update the scene to render `SpawnPreviewList`
- add zustand store `useSpawnPreviews`
- document the feature in the README

## Testing
- `npm install`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_684f75c619408326a4bd32140f4c9889