### PR TITLE
Add CI workflow and clarify setup steps

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,17 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
+        with:
+          node-version: '18'
+      - run: npm ci
+      - run: npx tsc --noEmit

--- a/README.md
+++ b/README.md
@@ -46,7 +46,8 @@ To get started with the project, follow these steps:
    ```
 
 2. **Install dependencies:**
-   ```
+   Run the following command from the project root to install all required packages:
+   ```bash
    npm install
    ```
 


### PR DESCRIPTION
## Summary
- clarify that you need to run `npm install` when getting started
- add GitHub Actions workflow to run TypeScript check

## Testing
- `npm ci`
- `npx tsc --noEmit`


------
https://chatgpt.com/codex/tasks/task_e_685064d8c5548326acd727cf1f051904