### PR TITLE
Spawn objects with animated entrance

### DIFF
--- a/src/components/SingleMusicalObject.tsx
+++ b/src/components/SingleMusicalObject.tsx
@@ -3,6 +3,7 @@ import React, { useRef, useState, useMemo, useEffect } from 'react'
 import { Mesh } from 'three'
 import { useSphere } from '@react-three/cannon'
 import { useFrame, useThree } from '@react-three/fiber'
+import { motion } from 'framer-motion-3d'
 import * as THREE from 'three'
 import * as Tone from 'tone'
 import { playNote, playChord, playBeat, getObjectMeter, getObjectPanner } from '../lib/audio'
@@ -80,37 +81,43 @@ export const SingleMusicalObject: React.FC<MusicalObjectProps> = ({ id, type, po
       const intensity = objectConfigs[type].pulseIntensity || 0
       const target = 1 + level * intensity
       mesh.scale.setScalar(THREE.MathUtils.lerp(mesh.scale.x, target, 0.2))
+      const mat = mesh.material as THREE.MeshStandardMaterial
+      mat.emissiveIntensity = THREE.MathUtils.lerp(mat.emissiveIntensity, 0.2 + level * 0.8, 0.2)
     }
   })
 
   return (
-    <mesh
-      ref={ref as React.MutableRefObject<Mesh>}
-      castShadow
-      receiveShadow
-      onPointerDown={(e) => { e.stopPropagation(); setDragging(true); setMoved(false) }}
-      onPointerUp={(e) => { e.stopPropagation(); setDragging(false) }}
-      onClick={(e) => {
-        e.stopPropagation()
-        if (!moved) select(id)
-        if (type === 'note') playNote(id)
-        if (type === 'chord') playChord(id)
-        if (type === 'beat' || type === 'loop') playBeat(id)
-      }}
-      onPointerMissed={() => setDragging(false)}
-    >
-      <ShapeFactory type={type} />
-      <meshStandardMaterial
-        color={objectConfigs[type].color}
-        metalness={0.4}
-        roughness={0.7}
-      />
-      {selected === id && (
-        <Html position={[0, 1, 0]} transform>
-          <EffectPanel objectId={id} />
-        </Html>
-      )}
-    </mesh>
+    <motion.group initial={{ scale: 0 }} animate={{ scale: 1 }} transition={{ type: 'spring', stiffness: 160, damping: 20 }}>
+      <mesh
+        ref={ref as React.MutableRefObject<Mesh>}
+        castShadow
+        receiveShadow
+        onPointerDown={(e) => { e.stopPropagation(); setDragging(true); setMoved(false) }}
+        onPointerUp={(e) => { e.stopPropagation(); setDragging(false) }}
+        onClick={(e) => {
+          e.stopPropagation()
+          if (!moved) select(id)
+          if (type === 'note') playNote(id)
+          if (type === 'chord') playChord(id)
+          if (type === 'beat' || type === 'loop') playBeat(id)
+        }}
+        onPointerMissed={() => setDragging(false)}
+      >
+        <ShapeFactory type={type} />
+        <meshStandardMaterial
+          color={objectConfigs[type].color}
+          emissive={objectConfigs[type].color}
+          emissiveIntensity={0.2}
+          metalness={0.4}
+          roughness={0.7}
+        />
+        {selected === id && (
+          <Html position={[0, 1, 0]} transform>
+            <EffectPanel objectId={id} />
+          </Html>
+        )}
+      </mesh>
+    </motion.group>
   )
 }
 

--- a/src/components/SoundPortals.tsx
+++ b/src/components/SoundPortals.tsx
@@ -1,6 +1,7 @@
 // src/components/SoundPortals.tsx
 import React, { useState } from 'react'
 import { Float, useCursor } from '@react-three/drei'
+import { useThree } from '@react-three/fiber'
 import { useObjects, ObjectType } from '../store/useObjects'
 import { usePortalRing } from './usePortalRing'
 import { objectConfigs, objectTypes } from '../config/objectTypes'
@@ -13,6 +14,7 @@ const portalConfigs: { type: ObjectType; color: string }[] = objectTypes.map((t)
 
 const Portal: React.FC<{ cfg: typeof portalConfigs[0]; position: [number, number, number] }> = ({ cfg, position }) => {
   const spawn = useObjects((state) => state.spawn)
+  const { camera } = useThree()
   const [hovered, setHovered] = useState(false)
   useCursor(hovered)
   return (
@@ -22,7 +24,10 @@ const Portal: React.FC<{ cfg: typeof portalConfigs[0]; position: [number, number
         receiveShadow
         onPointerOver={() => setHovered(true)}
         onPointerOut={() => setHovered(false)}
-        onClick={() => spawn(cfg.type)}
+        onClick={() => {
+          const pos: [number, number, number] = [camera.position.x, camera.position.y, camera.position.z]
+          spawn(cfg.type, pos)
+        }}
       >
         <ShapeFactory type={cfg.type} />
         <meshStandardMaterial

--- a/src/components/SpawnMenu.tsx
+++ b/src/components/SpawnMenu.tsx
@@ -1,6 +1,7 @@
 // src/components/SpawnMenu.tsx
 import React, { useState } from 'react'
 import { Float, useCursor } from '@react-three/drei'
+import { useThree } from '@react-three/fiber'
 import { useObjects } from '../store/useObjects'
 import { objectConfigs, objectTypes, ObjectType } from '../config/objectTypes'
 import { playNote, playChord, playBeat, startLoop } from '../lib/audio'
@@ -10,13 +11,19 @@ interface ItemProps { type: ObjectType; index: number }
 
 const MenuItem: React.FC<ItemProps> = ({ type, index }) => {
   const spawn = useObjects((s) => s.spawn)
+  const { camera } = useThree()
   const [hovered, setHovered] = useState(false)
   const [active, setActive] = useState(false)
   useCursor(hovered)
 
   const handlePointerUp = () => {
     setActive(false)
-    const id = spawn(type)
+    const pos: [number, number, number] = [
+      camera.position.x,
+      camera.position.y,
+      camera.position.z,
+    ]
+    const id = spawn(type, pos)
     if (type === 'note') playNote(id)
     else if (type === 'chord') playChord(id)
     else if (type === 'beat') playBeat(id)

--- a/src/store/useObjects.ts
+++ b/src/store/useObjects.ts
@@ -14,19 +14,19 @@ interface ObjectState {
   /**
    * Spawn a new musical object of the given type and return its id
    */
-  spawn: (type: ObjectType) => string
+  spawn: (type: ObjectType, position?: [number, number, number]) => string
 }
 
 export const useObjects = create<ObjectState>((set, get) => ({
   objects: [],
-  spawn: (type) => {
+  spawn: (type, position) => {
     const id = Date.now().toString()
     const newObj: MusicalObject = {
       id,
       type,
-      position: [0, 3, 0], // default spawn position
+      position: position ?? [0, 3, 0],
     }
-    set({ objects: [...get().objects, newObj] });
+    set({ objects: [...get().objects, newObj] })
     addBody(id, newObj.position)
     return id
   },


### PR DESCRIPTION
## Summary
- allow passing a position into `spawn`
- drop new items at the camera position from SpawnMenu and SoundPortals
- animate new meshes from scale 0 to 1 and pulse emissive intensity

## Testing
- `npx tsc --noEmit` *(fails: Cannot find module 'react' or its corresponding type declarations)*

------
https://chatgpt.com/codex/tasks/task_e_68506ce60d048326bf4e579a9bfe8318