### PR TITLE
Float effect panel near selected objects

### DIFF
--- a/src/components/EffectPanel.tsx
+++ b/src/components/EffectPanel.tsx
@@ -1,5 +1,6 @@
 "use client";
 import React from "react";
+import { Html } from "@react-three/drei";
 import { motion } from "framer-motion";
 import {
   useEffectSettings,
@@ -9,31 +10,36 @@ import styles from "../styles/effectPanel.module.css";
 import ui from "../styles/ui.module.css";
 
 interface EffectPanelProps {
-  objectId: string;
+  objectId: string
+  position?: [number, number, number]
 }
 
 const container = {
-  initial: {},
-  animate: { transition: { staggerChildren: 0.1 } },
-};
+  initial: { y: 10, opacity: 0 },
+  animate: { y: 0, opacity: 1, transition: { staggerChildren: 0.1 } },
+  exit: { y: 10, opacity: 0 },
+}
 const item = {
   initial: { y: 20, opacity: 0 },
   animate: { y: 0, opacity: 1 },
-};
+  exit: { y: 20, opacity: 0 },
+}
 
-const EffectPanel: React.FC<EffectPanelProps> = ({ objectId }) => {
+const EffectPanel: React.FC<EffectPanelProps> = ({ objectId, position = [0, 1, 0] }) => {
   const params = useEffectSettings(
     (s) => s.effects[objectId] || defaultEffectParams,
   );
   const setEffect = useEffectSettings((s) => s.setEffect);
 
   return (
-    <motion.div
-      className={`${styles.panel} ${ui.glass}`}
-      variants={container}
-      initial="initial"
-      animate="animate"
-    >
+    <Html position={position} transform>
+      <motion.div
+        className={`${styles.panel} ${ui.glass}`}
+        variants={container}
+        initial="initial"
+        animate="animate"
+        exit="exit"
+      >
       <motion.div className={styles.row} variants={item}>
         <label>Reverb</label>
         <motion.input
@@ -94,8 +100,9 @@ const EffectPanel: React.FC<EffectPanelProps> = ({ objectId }) => {
           whileTap={{ scale: 1.1 }}
         />
       </motion.div>
-    </motion.div>
-  );
+      </motion.div>
+    </Html>
+  )
 };
 
 export default EffectPanel;

--- a/src/components/MusicalObject.tsx
+++ b/src/components/MusicalObject.tsx
@@ -1,6 +1,7 @@
 // src/components/MusicalObject.tsx
 import React, { useMemo } from 'react'
-import { Instances, Instance, Html } from '@react-three/drei'
+import { Instances, Instance } from '@react-three/drei'
+import { AnimatePresence } from 'framer-motion'
 import { objectConfigs, objectTypes, ObjectType } from '../config/objectTypes'
 import { useObjects, MusicalObject as Obj } from '../store/useObjects'
 import ShapeFactory from './ShapeFactory'
@@ -66,11 +67,14 @@ const MusicalObjectInstances: React.FC = () => {
           </Instances>
         )
       })}
-      {selected && transforms[selected] && (
-        <Html position={transforms[selected].position} transform>
-          <EffectPanel objectId={selected} />
-        </Html>
-      )}
+      <AnimatePresence>
+        {selected && transforms[selected] && (
+          <EffectPanel
+            objectId={selected}
+            position={transforms[selected].position as [number, number, number]}
+          />
+        )}
+      </AnimatePresence>
     </>
   )
 }

--- a/src/components/SingleMusicalObject.tsx
+++ b/src/components/SingleMusicalObject.tsx
@@ -10,7 +10,7 @@ import { playNote, playChord, playBeat, getObjectMeter, getObjectPanner } from '
 import { ObjectType } from '../store/useObjects'
 import { objectConfigs } from '../config/objectTypes'
 import ShapeFactory from './ShapeFactory'
-import { Html } from '@react-three/drei'
+import { AnimatePresence } from 'framer-motion'
 import { useEffectSettings } from '../store/useEffectSettings'
 import EffectPanel from './EffectPanel'
 
@@ -117,11 +117,11 @@ export const SingleMusicalObject: React.FC<MusicalObjectProps> = ({ id, type, po
           metalness={0.4}
           roughness={0.7}
         />
-        {selected === id && (
-          <Html position={[0, 1, 0]} transform>
-            <EffectPanel objectId={id} />
-          </Html>
-        )}
+        <AnimatePresence>
+          {selected === id && (
+            <EffectPanel objectId={id} position={[0, 1, 0]} />
+          )}
+        </AnimatePresence>
       </mesh>
     </a.group>
   )

--- a/src/styles/effectPanel.module.css
+++ b/src/styles/effectPanel.module.css
@@ -1,21 +1,22 @@
 .panel {
   position: relative;
-  background: rgba(20, 20, 30, 0.5);
-  backdrop-filter: blur(12px);
-  box-shadow: 0 0 10px rgba(255, 255, 255, 0.1);
-  border-radius: 0.75rem;
-  padding: 0.5rem;
+  width: 140px;
+  background: rgba(20, 20, 30, 0.6);
+  backdrop-filter: blur(8px);
+  box-shadow: 0 0 6px rgba(255, 255, 255, 0.1);
+  border-radius: 0.5rem;
+  padding: 0.4rem;
   display: flex;
   flex-direction: column;
-  gap: 0.5rem;
+  gap: 0.4rem;
   color: var(--fg);
-  min-width: 160px;
+  pointer-events: auto;
 }
 
 .row {
   display: flex;
   align-items: center;
-  gap: 0.5rem;
+  gap: 0.4rem;
 }
 
 .slider {
@@ -46,11 +47,11 @@
 .knob {
   -webkit-appearance: none;
   appearance: none;
-  width: 40px;
-  height: 40px;
+  width: 36px;
+  height: 36px;
   border-radius: 50%;
   border: 2px solid var(--accent2);
-  background: rgba(255,255,255,0.1);
+  background: rgba(255, 255, 255, 0.1);
   cursor: pointer;
   transform: rotate(-90deg);
 }


### PR DESCRIPTION
## Summary
- float `EffectPanel` in 3D space using `<Html>`
- animate panel mounting with `AnimatePresence`
- compact floating styles for `effectPanel`

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_685071588ef08326ab98380e8efedbbd