### PR TITLE
Add GPU particle burst component

### DIFF
--- a/src/components/ParticleBurst.tsx
+++ b/src/components/ParticleBurst.tsx
@@ -1,0 +1,162 @@
+'use client'
+import React, { useEffect, useRef, useImperativeHandle, forwardRef } from 'react'
+import { useThree, useFrame } from '@react-three/fiber'
+import * as THREE from 'three'
+import { GPUComputationRenderer } from 'three/examples/jsm/misc/GPUComputationRenderer'
+import { beatBus } from '../lib/events'
+
+export interface ParticleBurstProps {
+  count?: number
+  color?: THREE.ColorRepresentation
+}
+
+export interface ParticleBurstHandle {
+  burst: () => void
+}
+
+const positionFragment = /* glsl */`
+  uniform sampler2D texturePosition;
+  uniform sampler2D textureVelocity;
+  uniform float delta;
+  void main(){
+    vec2 uv = gl_FragCoord.xy / resolution.xy;
+    vec3 pos = texture2D( texturePosition, uv ).xyz;
+    vec3 vel = texture2D( textureVelocity, uv ).xyz;
+    gl_FragColor = vec4( pos + vel * delta, 1.0 );
+  }
+`
+
+const velocityFragment = /* glsl */`
+  uniform sampler2D texturePosition;
+  uniform sampler2D textureVelocity;
+  uniform float delta;
+  uniform float burst;
+  float rand(vec2 co){
+    return fract(sin(dot(co.xy,vec2(12.9898,78.233)))*43758.5453);
+  }
+  void main(){
+    vec2 uv = gl_FragCoord.xy / resolution.xy;
+    vec3 pos = texture2D( texturePosition, uv ).xyz;
+    vec3 vel = texture2D( textureVelocity, uv ).xyz * 0.98;
+    if(burst>0.0){
+      vel += normalize(pos+0.0001)*burst*5.0;
+      vel += vec3(rand(uv),rand(uv*1.3),rand(uv*2.1))*2.0*burst;
+    }
+    gl_FragColor = vec4( vel, 1.0 );
+  }
+`
+
+const renderVertex = /* glsl */`
+  uniform sampler2D positions;
+  varying vec2 vUv;
+  void main(){
+    vUv = uv;
+    vec3 pos = texture2D( positions, uv ).xyz;
+    vec4 mvPosition = modelViewMatrix * vec4( pos, 1.0 );
+    gl_Position = projectionMatrix * mvPosition;
+    gl_PointSize = 2.0;
+  }
+`
+
+const renderFragment = /* glsl */`
+  uniform vec3 color;
+  varying vec2 vUv;
+  void main(){
+    gl_FragColor = vec4( color, 1.0 );
+  }
+`
+
+const ParticleBurst = forwardRef<ParticleBurstHandle, ParticleBurstProps>(
+  ({ count = 1024, color = '#ff88aa' }, ref) => {
+    const { gl } = useThree()
+    const size = Math.ceil(Math.sqrt(count))
+    const gpu = useRef<GPUComputationRenderer | null>(null)
+    const posVar = useRef<any>(null)
+    const velVar = useRef<any>(null)
+    const meshRef = useRef<THREE.Points>(null)
+
+    const burst = () => {
+      if (velVar.current) velVar.current.material.uniforms.burst.value = 1
+    }
+
+    useImperativeHandle(ref, () => ({ burst }))
+
+    useEffect(() => {
+      const compute = new GPUComputationRenderer(size, size, gl)
+      const dtPos = compute.createTexture()
+      const dtVel = compute.createTexture()
+      const fill = (tex: THREE.DataTexture) => {
+        const arr = tex.image.data as Float32Array
+        for (let i = 0; i < arr.length; i += 4) {
+          arr[i] = (Math.random() - 0.5) * 4
+          arr[i + 1] = (Math.random() - 0.5) * 4
+          arr[i + 2] = (Math.random() - 0.5) * 4
+          arr[i + 3] = 1
+        }
+      }
+      fill(dtPos)
+      fill(dtVel)
+      posVar.current = compute.addVariable('texturePosition', positionFragment, dtPos)
+      velVar.current = compute.addVariable('textureVelocity', velocityFragment, dtVel)
+      compute.setVariableDependencies(posVar.current, [posVar.current, velVar.current])
+      compute.setVariableDependencies(velVar.current, [posVar.current, velVar.current])
+      velVar.current.material.uniforms.delta = { value: 0 }
+      velVar.current.material.uniforms.burst = { value: 0 }
+      posVar.current.material.uniforms.delta = { value: 0 }
+      const err = compute.init()
+      if (err) console.error(err)
+      gpu.current = compute
+    }, [gl, size])
+
+    useFrame((state) => {
+      const compute = gpu.current
+      if (!compute || !posVar.current || !velVar.current) return
+      const delta = state.clock.getDelta()
+      velVar.current.material.uniforms.delta.value = delta
+      posVar.current.material.uniforms.delta.value = delta
+      compute.compute()
+      velVar.current.material.uniforms.burst.value = 0
+      const mat = meshRef.current!.material as THREE.ShaderMaterial
+      mat.uniforms.positions.value = compute.getCurrentRenderTarget(posVar.current).texture
+    })
+
+    useEffect(() => {
+      const handler = () => burst()
+      beatBus.addEventListener('beat', handler)
+      return () => beatBus.removeEventListener('beat', handler)
+    }, [])
+
+    const geometry = React.useMemo(() => {
+      const geo = new THREE.BufferGeometry()
+      const positions = new Float32Array(size * size * 3)
+      const uvs = new Float32Array(size * size * 2)
+      let p = 0
+      let u = 0
+      for (let i = 0; i < size; i++) {
+        for (let j = 0; j < size; j++) {
+          positions[p++] = 0
+          positions[p++] = 0
+          positions[p++] = 0
+          uvs[u++] = i / size
+          uvs[u++] = j / size
+        }
+      }
+      geo.setAttribute('position', new THREE.BufferAttribute(positions, 3))
+      geo.setAttribute('uv', new THREE.BufferAttribute(uvs, 2))
+      return geo
+    }, [size])
+
+    return (
+      <points ref={meshRef} geometry={geometry} frustumCulled={false}>
+        <shaderMaterial
+          uniforms={{ positions: { value: null }, color: { value: new THREE.Color(color) } }}
+          vertexShader={renderVertex}
+          fragmentShader={renderFragment}
+          transparent
+        />
+      </points>
+    )
+  }
+)
+ParticleBurst.displayName = 'ParticleBurst'
+export default ParticleBurst

--- a/src/components/SceneCanvas.tsx
+++ b/src/components/SceneCanvas.tsx
@@ -12,6 +12,7 @@ import SpawnMenu from './SpawnMenu'
 import EffectWorm from './EffectWorm'
 import LoopProgress from './LoopProgress'
 import HUD from './HUD'
+import ParticleBurst from './ParticleBurst'
 import { startNote, stopNote } from '../lib/audio'
 import { initPhysics } from '../lib/physics'
 
@@ -113,6 +114,7 @@ const SceneCanvas: React.FC = () => {
           <SoundPortals />
           <SpawnMenu />
         </Physics>
+        <ParticleBurst count={1024} color="#ff66aa" />
         <HUD />
       </Canvas>
     </div>

--- a/src/lib/audio.ts
+++ b/src/lib/audio.ts
@@ -5,6 +5,7 @@ import { useEffectSettings, defaultEffectParams, EffectParams } from '../store/u
 import { ObjectType } from '../store/useObjects'
 import { useLoops } from '../store/useLoops'
 
+import { beatBus } from "./events"
 // Synth instances (initialized once)
 let noteSynth: Tone.Synth
 let chordSynth: Tone.PolySynth
@@ -147,6 +148,7 @@ export async function playChord(id: string, notes: string[] = ['C4', 'E4', 'G4']
  * Play a beat kick.
  */
 export async function playBeat(id: string) {
+  beatBus.dispatchEvent(new Event("beat"));
   await initAudioEngine()
   const { key } = useAudioSettings.getState()
   const note = transpose('C2', key)

--- a/src/lib/events.ts
+++ b/src/lib/events.ts
@@ -1,0 +1,1 @@
+export const beatBus = new EventTarget()


### PR DESCRIPTION
## Summary
- add new `ParticleBurst` component driven by GPUComputationRenderer
- expose a beat event bus and dispatch from `playBeat`
- render particle bursts in `SceneCanvas`

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_685658b81adc83269b335702849227a8