### PR TITLE
Add 'use client' directive to React hook components

### DIFF
--- a/src/components/EffectWorm.tsx
+++ b/src/components/EffectWorm.tsx
@@ -1,3 +1,4 @@
+'use client'
 // src/components/EffectWorm.tsx
 import React, { useRef } from 'react'
 import { useSphere } from '@react-three/cannon'

--- a/src/components/FloatingSphere.tsx
+++ b/src/components/FloatingSphere.tsx
@@ -1,3 +1,4 @@
+'use client'
 import React, { useRef } from 'react';
 import { useFrame } from '@react-three/fiber';
 import { Sphere } from '@react-three/drei';

--- a/src/components/Floor.tsx
+++ b/src/components/Floor.tsx
@@ -1,3 +1,4 @@
+'use client'
 // src/components/Floor.tsx
 import React from 'react'
 import { usePlane } from '@react-three/cannon'

--- a/src/components/MusicalObject.tsx
+++ b/src/components/MusicalObject.tsx
@@ -1,3 +1,4 @@
+'use client'
 // src/components/MusicalObject.tsx
 import React, { useMemo } from 'react'
 import { Instances, Instance } from '@react-three/drei'

--- a/src/components/SingleMusicalObject.tsx
+++ b/src/components/SingleMusicalObject.tsx
@@ -1,3 +1,4 @@
+'use client'
 // src/components/MusicalObject.tsx
 import React, { useRef, useState, useMemo, useEffect } from 'react'
 import { Object3D } from 'three'

--- a/src/components/SoundPortals.tsx
+++ b/src/components/SoundPortals.tsx
@@ -1,3 +1,4 @@
+'use client'
 // src/components/SoundPortals.tsx
 import React, { useState } from 'react'
 import { Float, useCursor } from '@react-three/drei'

--- a/src/components/SpawnMenu.tsx
+++ b/src/components/SpawnMenu.tsx
@@ -1,3 +1,4 @@
+'use client'
 // src/components/SpawnMenu.tsx
 import React, { useState } from 'react'
 import { Float, useCursor } from '@react-three/drei'

--- a/src/components/usePortalRing.tsx
+++ b/src/components/usePortalRing.tsx
@@ -1,3 +1,4 @@
+'use client'
 import { useRef } from 'react'
 import { useFrame, useThree } from '@react-three/fiber'
 import type { Group } from 'three'


### PR DESCRIPTION
## Summary
- insert `'use client'` at the top of several components that use React hooks

## Testing
- `npm ci`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6856daeae71c8326a238e5755c3c3f46