### PR TITLE
Add baseScale for objects

### DIFF
--- a/src/components/MusicalObject.tsx
+++ b/src/components/MusicalObject.tsx
@@ -55,6 +55,7 @@ const MusicalObjectInstances: React.FC = () => {
                   color={objectConfigs[t].color}
                   position={pos as any}
                   rotation={rot}
+                  scale={objectConfigs[t].baseScale}
                   onClick={(e) => {
                     e.stopPropagation()
                     select(obj.id)

--- a/src/components/SingleMusicalObject.tsx
+++ b/src/components/SingleMusicalObject.tsx
@@ -97,6 +97,7 @@ export const SingleMusicalObject: React.FC<MusicalObjectProps> = ({ id, type, po
     <a.group scale={springs.scale}>
       <group
         ref={ref as React.MutableRefObject<Object3D>}
+        scale={objectConfigs[type].baseScale}
         onPointerDown={(e) => { e.stopPropagation(); setDragging(true); setMoved(false) }}
         onPointerUp={(e) => { e.stopPropagation(); setDragging(false) }}
         onClick={(e) => {

--- a/src/components/SoundPortals.tsx
+++ b/src/components/SoundPortals.tsx
@@ -23,6 +23,7 @@ const Portal: React.FC<{ cfg: typeof portalConfigs[0]; position: [number, number
       <mesh
         castShadow
         receiveShadow
+        scale={objectConfigs[cfg.type].baseScale}
         onPointerOver={() => setHovered(true)}
         onPointerOut={() => setHovered(false)}
         onClick={() => {

--- a/src/config/objectTypes.ts
+++ b/src/config/objectTypes.ts
@@ -9,13 +9,15 @@ export interface ObjectConfig {
   /** Unicode glyph used for text icons */
   icon: string
   pulseIntensity?: number
+  /** Base scale applied to the mesh */
+  baseScale: number
 }
 
 export const objectConfigs: Record<ObjectType, ObjectConfig> = {
-  note:  { color:'#4fa3ff', label:'Note',  geometry:'sphere',    icon:'\u2669',  pulseIntensity:0.5 },
-  chord: { color:'#6ee7b7', label:'Chord', geometry:'torus',     icon:'\u266C',  pulseIntensity:0.3 },
-  beat:  { color:'#a0aec0', label:'Beat',  geometry:'cube',      icon:'\u266A',  pulseIntensity:0.7 },
-  loop:  { color:'#f472b6', label:'Loop',  geometry:'torusKnot', icon:'\u1D106', pulseIntensity:0.4 },
+  note:  { color:'#4fa3ff', label:'Note',  geometry:'sphere',    icon:'\u2669',  pulseIntensity:0.5, baseScale:1 },
+  chord: { color:'#6ee7b7', label:'Chord', geometry:'torus',     icon:'\u266C',  pulseIntensity:0.3, baseScale:1.2 },
+  beat:  { color:'#a0aec0', label:'Beat',  geometry:'cube',      icon:'\u266A',  pulseIntensity:0.7, baseScale:1 },
+  loop:  { color:'#f472b6', label:'Loop',  geometry:'torusKnot', icon:'\u1D106', pulseIntensity:0.4, baseScale:1 },
 }
 
 export const objectTypes = Object.keys(objectConfigs) as ObjectType[]


### PR DESCRIPTION
## Summary
- support configurable baseScale for musical objects
- scale meshes in SingleMusicalObject, MusicalObject instances and sound portals

## Testing
- `npm run build` *(fails: next not installed)*

------
https://chatgpt.com/codex/tasks/task_e_6856de66a75c8326bdc2222b77066977