### PR TITLE
Switch worker to Rapier physics

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "name": "interactive-music-3d",
       "version": "1.0.0",
       "dependencies": {
+        "@dimforge/rapier3d-compat": "^0.12.0",
         "@react-spring/three": "^10.0.1",
         "@react-three/cannon": "^6.6.0",
         "@react-three/drei": "^10.2.0",

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "@react-three/drei": "^10.2.0",
     "@react-three/fiber": "latest",
     "@react-three/postprocessing": "^3.0.4",
+    "@dimforge/rapier3d-compat": "^0.12.0",
     "cannon-es": "^0.20.0",
     "framer-motion": "^12.18.1",
     "framer-motion-3d": "^12.4.13",

--- a/src/lib/physics.worker.ts
+++ b/src/lib/physics.worker.ts
@@ -1,44 +1,59 @@
-import * as CANNON from 'cannon-es'
+import RAPIER from '@dimforge/rapier3d-compat'
 
 interface AddMsg { type: 'add'; id: string; position: [number, number, number] }
 interface RemoveMsg { type: 'remove'; id: string }
 type Msg = AddMsg | RemoveMsg
 
-const world = new CANNON.World()
-world.gravity.set(0, -9.82, 0)
-const bodies: Record<string, CANNON.Body> = {}
+let world: RAPIER.World | null = null
+const bodies: Record<string, RAPIER.RigidBody> = {}
+const colliders: Record<string, RAPIER.Collider> = {}
 
 function step() {
-  world.step(1 / 30)
-  const updates = Object.entries(bodies).map(([id, body]) => ({
-    id,
-    position: [body.position.x, body.position.y, body.position.z],
-    quaternion: [
-      body.quaternion.x,
-      body.quaternion.y,
-      body.quaternion.z,
-      body.quaternion.w,
-    ],
-  }))
+  if (!world) return
+  world.step()
+  const updates = Object.entries(bodies).map(([id, body]) => {
+    const t = body.translation()
+    const r = body.rotation()
+    return {
+      id,
+      position: [t.x, t.y, t.z] as [number, number, number],
+      quaternion: [r.x, r.y, r.z, r.w] as [number, number, number, number],
+    }
+  })
   ;(postMessage as any)(updates)
 }
 
-setInterval(step, 1000 / 30)
+RAPIER.init().then(() => {
+  world = new RAPIER.World({ x: 0, y: -9.82, z: 0 })
+  world.timestep = 1 / 30
+  setInterval(step, 1000 / 30)
+})
 
 onmessage = (e: MessageEvent<Msg>) => {
+  if (!world) return
   const data = e.data
   if (data.type === 'add') {
-    const body = new CANNON.Body({
-      mass: 1,
-      shape: new CANNON.Sphere(0.5),
-      position: new CANNON.Vec3(...data.position),
-    })
+    const rbDesc = RAPIER.RigidBodyDesc.dynamic().setTranslation(
+      data.position[0],
+      data.position[1],
+      data.position[2]
+    )
+    const body = world.createRigidBody(rbDesc)
+    const collider = world.createCollider(
+      RAPIER.ColliderDesc.ball(0.5),
+      body
+    )
     bodies[data.id] = body
-    world.addBody(body)
+    colliders[data.id] = collider
   } else if (data.type === 'remove') {
     const body = bodies[data.id]
+    const collider = colliders[data.id]
+    if (collider) {
+      world.removeCollider(collider, true)
+      delete colliders[data.id]
+    }
     if (body) {
-      world.removeBody(body)
+      world.removeRigidBody(body)
       delete bodies[data.id]
     }
   }


### PR DESCRIPTION
## Summary
- swap `cannon-es` for `@dimforge/rapier3d-compat`
- create and update rigid bodies inside the worker
- configure Rapier world timestep
- add Rapier dependency

## Testing
- `npm ci`
- `npx tsc --noEmit`

------
https://chatgpt.com/codex/tasks/task_e_6856e7004bd48326b9f54cd42331b0d7