### PR TITLE
Add base scale for musical objects

### DIFF
--- a/src/components/SingleMusicalObject.tsx
+++ b/src/components/SingleMusicalObject.tsx
@@ -79,8 +79,9 @@ export const SingleMusicalObject: React.FC<MusicalObjectProps> = ({ id, type, po
     if (meter) {
       const raw = meter.getValue()
       const level = Array.isArray(raw) ? raw[0] : raw
-      const intensity = objectConfigs[type].pulseIntensity || 0
-      const target = 1 + level * intensity
+      const cfg = objectConfigs[type]
+      const intensity = cfg.pulseIntensity || 0
+      const target = cfg.baseScale * (1 + level * intensity)
       mesh.scale.setScalar(THREE.MathUtils.lerp(mesh.scale.x, target, 0.2))
       const mat = mesh.material as THREE.MeshStandardMaterial
       mat.emissiveIntensity = THREE.MathUtils.lerp(mat.emissiveIntensity, 0.2 + level * 0.8, 0.2)

--- a/src/config/objectTypes.ts
+++ b/src/config/objectTypes.ts
@@ -14,10 +14,14 @@ export interface ObjectConfig {
 }
 
 export const objectConfigs: Record<ObjectType, ObjectConfig> = {
-  note:  { color:'#4fa3ff', label:'Note',  geometry:'sphere',    icon:'\u2669',  pulseIntensity:0.5, baseScale:1 },
+  // Slightly smaller notes for a more delicate feel
+  note:  { color:'#4fa3ff', label:'Note',  geometry:'sphere',    icon:'\u2669',  pulseIntensity:0.5, baseScale:0.8 },
+  // Chords are generally more prominent
   chord: { color:'#6ee7b7', label:'Chord', geometry:'torus',     icon:'\u266C',  pulseIntensity:0.3, baseScale:1.2 },
+  // Beats sit between notes and loops
   beat:  { color:'#a0aec0', label:'Beat',  geometry:'cube',      icon:'\u266A',  pulseIntensity:0.7, baseScale:1 },
-  loop:  { color:'#f472b6', label:'Loop',  geometry:'torusKnot', icon:'\u1D106', pulseIntensity:0.4, baseScale:1 },
+  // Loops are slightly larger to stand out
+  loop:  { color:'#f472b6', label:'Loop',  geometry:'torusKnot', icon:'\u1D106', pulseIntensity:0.4, baseScale:1.1 },
 }
 
 export const objectTypes = Object.keys(objectConfigs) as ObjectType[]


### PR DESCRIPTION
## Summary
- tune default scales for musical objects
- incorporate baseScale when pulsing meshes

## Testing
- `npx tsc --noEmit`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6856f64c0bec83269a71be0b3995a841