### PR TITLE
Add LOD optimisation for sound portals

### DIFF
--- a/src/components/SoundPortals.tsx
+++ b/src/components/SoundPortals.tsx
@@ -1,12 +1,15 @@
 'use client'
 // src/components/SoundPortals.tsx
-import React, { useState } from 'react'
-import { Float, useCursor } from '@react-three/drei'
+import React, { useState, useMemo } from 'react'
+import { Float, useCursor, Detailed } from '@react-three/drei'
 import { useThree } from '@react-three/fiber'
 import { useObjects, ObjectType } from '../store/useObjects'
 import { usePortalRing } from './usePortalRing'
 import { objectConfigs, objectTypes } from '../config/objectTypes'
 import ShapeFactory from './ShapeFactory'
+import * as BufferGeometryUtils from 'three/examples/jsm/utils/BufferGeometryUtils'
+import * as THREE from 'three'
+import { usePerformance } from '../store/usePerformance'
 
 const portalConfigs: { type: ObjectType; color: string }[] = objectTypes.map((t) => ({
   type: t,
@@ -46,11 +49,44 @@ const Portal: React.FC<{ cfg: typeof portalConfigs[0]; position: [number, number
 
 const SoundPortals: React.FC = () => {
   const { groupRef, getPosition } = usePortalRing(portalConfigs.length)
-  return (
-    <group ref={groupRef}>
+  const lod = usePerformance((s) => s.lod)
+
+  const merged = useMemo(() => {
+    const geoms = portalConfigs.map((cfg, idx) => {
+      const g = new THREE.SphereGeometry(2, 8, 8)
+      g.translate(...getPosition(idx))
+      const color = new THREE.Color(cfg.color)
+      const count = g.attributes.position.count
+      const colors = new Float32Array(count * 3)
+      for (let i = 0; i < count; i++) {
+        colors[i * 3] = color.r
+        colors[i * 3 + 1] = color.g
+        colors[i * 3 + 2] = color.b
+      }
+      g.setAttribute('color', new THREE.BufferAttribute(colors, 3))
+      return g
+    })
+    return BufferGeometryUtils.mergeGeometries(geoms)
+  }, [getPosition])
+
+  const portals = (
+    <>
       {portalConfigs.map((cfg, idx) => (
         <Portal key={cfg.type} cfg={cfg} position={getPosition(idx)} />
       ))}
+    </>
+  )
+
+  if (!lod) return <group ref={groupRef}>{portals}</group>
+
+  return (
+    <group ref={groupRef}>
+      <Detailed distances={[8]}>
+        <group>{portals}</group>
+        <mesh geometry={merged} castShadow receiveShadow>
+          <meshStandardMaterial vertexColors metalness={0.5} roughness={0.4} />
+        </mesh>
+      </Detailed>
     </group>
   )
 }

--- a/src/store/usePerformance.ts
+++ b/src/store/usePerformance.ts
@@ -2,10 +2,14 @@ import { create } from 'zustand'
 
 interface PerfState {
   instanced: boolean
+  lod: boolean
   toggleInstanced: () => void
+  toggleLod: () => void
 }
 
 export const usePerformance = create<PerfState>((set) => ({
   instanced: false,
+  lod: true,
   toggleInstanced: () => set((s) => ({ instanced: !s.instanced })),
+  toggleLod: () => set((s) => ({ lod: !s.lod })),
 }))


### PR DESCRIPTION
## Summary
- add `lod` setting to performance store
- merge sound portal geometries for low detail view
- use `<Detailed>` to switch between high/low detail

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_685700c933a0832697f461d0bc48d78e