### PR TITLE
Add ErrorBoundary wrapper

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -4,6 +4,7 @@ import ui from '../src/styles/ui.module.css'
 import React from 'react'
 import PluginLoader from "./PluginLoader"
 import AudioSettingsPanel from '@/components/AudioSettingsPanel'
+import ErrorBoundary from '@/components/ErrorBoundary'
 
 export const metadata = {
   title: 'Interactive Music 3D',
@@ -14,9 +15,11 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
   return (
     <html lang="en">
       <body className={ui.root}>
-        <AudioSettingsPanel />
-        <PluginLoader />
-        {children}
+        <ErrorBoundary>
+          <AudioSettingsPanel />
+          <PluginLoader />
+          {children}
+        </ErrorBoundary>
       </body>
     </html>
   )

--- a/src/components/ErrorBoundary.tsx
+++ b/src/components/ErrorBoundary.tsx
@@ -1,0 +1,38 @@
+'use client'
+import React, { ErrorInfo, ReactNode } from 'react'
+import ui from '../styles/ui.module.css'
+
+interface Props {
+  children: ReactNode
+}
+interface State {
+  hasError: boolean
+}
+
+class ErrorBoundary extends React.Component<Props, State> {
+  constructor(props: Props) {
+    super(props)
+    this.state = { hasError: false }
+  }
+
+  static getDerivedStateFromError(_: Error): State {
+    return { hasError: true }
+  }
+
+  componentDidCatch(error: Error, errorInfo: ErrorInfo) {
+    console.error('ErrorBoundary caught an error', error, errorInfo)
+  }
+
+  render() {
+    if (this.state.hasError) {
+      return (
+        <div className={ui.glass} style={{ padding: '1rem', color: 'red' }}>
+          Something went wrong.
+        </div>
+      )
+    }
+    return this.props.children
+  }
+}
+
+export default ErrorBoundary


### PR DESCRIPTION
## Summary
- add `ErrorBoundary` component to catch rendering errors
- wrap layout body content with `ErrorBoundary`

## Testing
- `npx tsc --noEmit`
- `npm run lint`
- `npm run build`
- `npm run start`

------
https://chatgpt.com/codex/tasks/task_e_68572602c0b083268ac0d660ed370d08