### PR TITLE
Pin dependencies and update outdated packages

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,30 +8,30 @@
       "name": "interactive-music-3d",
       "version": "1.0.0",
       "dependencies": {
-        "@dimforge/rapier3d-compat": "^0.12.0",
+        "@dimforge/rapier3d-compat": "^0.17.3",
         "@react-spring/three": "^10.0.1",
         "@react-three/cannon": "^6.6.0",
-        "@react-three/drei": "^10.2.0",
-        "@react-three/fiber": "latest",
+        "@react-three/drei": "^10.3.0",
+        "@react-three/fiber": "9.1.2",
         "@react-three/postprocessing": "^3.0.4",
         "cannon-es": "^0.20.0",
         "framer-motion": "^12.18.1",
         "framer-motion-3d": "^12.4.13",
-        "meyda": "latest",
-        "next": "latest",
+        "meyda": "5.6.3",
+        "next": "15.3.4",
         "postprocessing": "^6.37.4",
-        "react": "latest",
-        "react-dom": "latest",
+        "react": "19.1.0",
+        "react-dom": "19.1.0",
         "three": "^0.177.0",
-        "tone": "latest",
+        "tone": "15.1.22",
         "zustand": "^5.0.5"
       },
       "devDependencies": {
-        "@types/node": "latest",
-        "@types/react": "latest",
+        "@types/node": "24.0.3",
+        "@types/react": "19.1.8",
         "eslint": "^9.29.0",
         "eslint-config-next": "^15.3.4",
-        "typescript": "latest"
+        "typescript": "5.8.3"
       }
     },
     "node_modules/@babel/runtime": {
@@ -44,9 +44,9 @@
       }
     },
     "node_modules/@dimforge/rapier3d-compat": {
-      "version": "0.12.0",
-      "resolved": "https://registry.npmjs.org/@dimforge/rapier3d-compat/-/rapier3d-compat-0.12.0.tgz",
-      "integrity": "sha512-uekIGetywIgopfD97oDL5PfeezkFpNhwlzlaEYNOA0N6ghdsOvh/HYjSMek5Q2O1PYvRSDFcqFVJl4r4ZBwOow==",
+      "version": "0.17.3",
+      "resolved": "https://registry.npmjs.org/@dimforge/rapier3d-compat/-/rapier3d-compat-0.17.3.tgz",
+      "integrity": "sha512-hxtaaqtfUWQvYbA/vstSEMZupObTMdM1u+5vTQlXNdWueRRhJ+toxREhaplok5W1/4ErxO6qdezbRM2eqEQsqw==",
       "license": "Apache-2.0"
     },
     "node_modules/@emnapi/core": {
@@ -780,9 +780,9 @@
       }
     },
     "node_modules/@next/env": {
-      "version": "15.3.3",
-      "resolved": "https://registry.npmjs.org/@next/env/-/env-15.3.3.tgz",
-      "integrity": "sha512-OdiMrzCl2Xi0VTjiQQUK0Xh7bJHnOuET2s+3V+Y40WJBAXrJeGA3f+I8MZJ/YQ3mVGi5XGR1L66oFlgqXhQ4Vw==",
+      "version": "15.3.4",
+      "resolved": "https://registry.npmjs.org/@next/env/-/env-15.3.4.tgz",
+      "integrity": "sha512-ZkdYzBseS6UjYzz6ylVKPOK+//zLWvD6Ta+vpoye8cW11AjiQjGYVibF0xuvT4L0iJfAPfZLFidaEzAOywyOAQ==",
       "license": "MIT"
     },
     "node_modules/@next/eslint-plugin-next": {
@@ -796,9 +796,9 @@
       }
     },
     "node_modules/@next/swc-darwin-arm64": {
-      "version": "15.3.3",
-      "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-15.3.3.tgz",
-      "integrity": "sha512-WRJERLuH+O3oYB4yZNVahSVFmtxRNjNF1I1c34tYMoJb0Pve+7/RaLAJJizyYiFhjYNGHRAE1Ri2Fd23zgDqhg==",
+      "version": "15.3.4",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-15.3.4.tgz",
+      "integrity": "sha512-z0qIYTONmPRbwHWvpyrFXJd5F9YWLCsw3Sjrzj2ZvMYy9NPQMPZ1NjOJh4ojr4oQzcGYwgJKfidzehaNa1BpEg==",
       "cpu": [
         "arm64"
       ],
@@ -812,9 +812,9 @@
       }
     },
     "node_modules/@next/swc-darwin-x64": {
-      "version": "15.3.3",
-      "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-15.3.3.tgz",
-      "integrity": "sha512-XHdzH/yBc55lu78k/XwtuFR/ZXUTcflpRXcsu0nKmF45U96jt1tsOZhVrn5YH+paw66zOANpOnFQ9i6/j+UYvw==",
+      "version": "15.3.4",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-15.3.4.tgz",
+      "integrity": "sha512-Z0FYJM8lritw5Wq+vpHYuCIzIlEMjewG2aRkc3Hi2rcbULknYL/xqfpBL23jQnCSrDUGAo/AEv0Z+s2bff9Zkw==",
       "cpu": [
         "x64"
       ],
@@ -828,9 +828,9 @@
       }
     },
     "node_modules/@next/swc-linux-arm64-gnu": {
-      "version": "15.3.3",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-15.3.3.tgz",
-      "integrity": "sha512-VZ3sYL2LXB8znNGcjhocikEkag/8xiLgnvQts41tq6i+wql63SMS1Q6N8RVXHw5pEUjiof+II3HkDd7GFcgkzw==",
+      "version": "15.3.4",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-15.3.4.tgz",
+      "integrity": "sha512-l8ZQOCCg7adwmsnFm8m5q9eIPAHdaB2F3cxhufYtVo84pymwKuWfpYTKcUiFcutJdp9xGHC+F1Uq3xnFU1B/7g==",
       "cpu": [
         "arm64"
       ],
@@ -844,9 +844,9 @@
       }
     },
     "node_modules/@next/swc-linux-arm64-musl": {
-      "version": "15.3.3",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-15.3.3.tgz",
-      "integrity": "sha512-h6Y1fLU4RWAp1HPNJWDYBQ+e3G7sLckyBXhmH9ajn8l/RSMnhbuPBV/fXmy3muMcVwoJdHL+UtzRzs0nXOf9SA==",
+      "version": "15.3.4",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-15.3.4.tgz",
+      "integrity": "sha512-wFyZ7X470YJQtpKot4xCY3gpdn8lE9nTlldG07/kJYexCUpX1piX+MBfZdvulo+t1yADFVEuzFfVHfklfEx8kw==",
       "cpu": [
         "arm64"
       ],
@@ -860,9 +860,9 @@
       }
     },
     "node_modules/@next/swc-linux-x64-gnu": {
-      "version": "15.3.3",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-15.3.3.tgz",
-      "integrity": "sha512-jJ8HRiF3N8Zw6hGlytCj5BiHyG/K+fnTKVDEKvUCyiQ/0r5tgwO7OgaRiOjjRoIx2vwLR+Rz8hQoPrnmFbJdfw==",
+      "version": "15.3.4",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-15.3.4.tgz",
+      "integrity": "sha512-gEbH9rv9o7I12qPyvZNVTyP/PWKqOp8clvnoYZQiX800KkqsaJZuOXkWgMa7ANCCh/oEN2ZQheh3yH8/kWPSEg==",
       "cpu": [
         "x64"
       ],
@@ -876,9 +876,9 @@
       }
     },
     "node_modules/@next/swc-linux-x64-musl": {
-      "version": "15.3.3",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-15.3.3.tgz",
-      "integrity": "sha512-HrUcTr4N+RgiiGn3jjeT6Oo208UT/7BuTr7K0mdKRBtTbT4v9zJqCDKO97DUqqoBK1qyzP1RwvrWTvU6EPh/Cw==",
+      "version": "15.3.4",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-15.3.4.tgz",
+      "integrity": "sha512-Cf8sr0ufuC/nu/yQ76AnarbSAXcwG/wj+1xFPNbyNo8ltA6kw5d5YqO8kQuwVIxk13SBdtgXrNyom3ZosHAy4A==",
       "cpu": [
         "x64"
       ],
@@ -892,9 +892,9 @@
       }
     },
     "node_modules/@next/swc-win32-arm64-msvc": {
-      "version": "15.3.3",
-      "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-15.3.3.tgz",
-      "integrity": "sha512-SxorONgi6K7ZUysMtRF3mIeHC5aA3IQLmKFQzU0OuhuUYwpOBc1ypaLJLP5Bf3M9k53KUUUj4vTPwzGvl/NwlQ==",
+      "version": "15.3.4",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-15.3.4.tgz",
+      "integrity": "sha512-ay5+qADDN3rwRbRpEhTOreOn1OyJIXS60tg9WMYTWCy3fB6rGoyjLVxc4dR9PYjEdR2iDYsaF5h03NA+XuYPQQ==",
       "cpu": [
         "arm64"
       ],
@@ -908,9 +908,9 @@
       }
     },
     "node_modules/@next/swc-win32-x64-msvc": {
-      "version": "15.3.3",
-      "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-15.3.3.tgz",
-      "integrity": "sha512-4QZG6F8enl9/S2+yIiOiju0iCTFd93d8VC1q9LZS4p/Xuk81W2QDjCFeoogmrWWkAD59z8ZxepBQap2dKS5ruw==",
+      "version": "15.3.4",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-15.3.4.tgz",
+      "integrity": "sha512-4kDt31Bc9DGyYs41FTL1/kNpDeHyha2TC0j5sRRoKCyrhNcfZ/nRQkAUlF27mETwm8QyHqIjHJitfcza2Iykfg==",
       "cpu": [
         "x64"
       ],
@@ -1070,9 +1070,9 @@
       }
     },
     "node_modules/@react-three/drei": {
-      "version": "10.2.0",
-      "resolved": "https://registry.npmjs.org/@react-three/drei/-/drei-10.2.0.tgz",
-      "integrity": "sha512-zd65A1f4Wy6rPt1kro0ZVNXl0D4CMzmwb8TU0yNOrnGquHB41hZcncRMPf9G4D4ue8mmIrYNv//8Gjexl2T8Kg==",
+      "version": "10.3.0",
+      "resolved": "https://registry.npmjs.org/@react-three/drei/-/drei-10.3.0.tgz",
+      "integrity": "sha512-+4NHCAUI38jp8XlbuKKWl/23y3F/JKdkvnYsrVXxhw150OyWKJoft+Yyd7dl6awxfV/Gn08x3R9pRRFUuDQwDA==",
       "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.26.0",
@@ -1304,9 +1304,9 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "24.0.1",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.0.1.tgz",
-      "integrity": "sha512-MX4Zioh39chHlDJbKmEgydJDS3tspMP/lnQC67G3SWsTnb9NeYVWOjkxpOSy4oMfPs4StcWHwBrvUb4ybfnuaw==",
+      "version": "24.0.3",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.0.3.tgz",
+      "integrity": "sha512-R4I/kzCYAdRLzfiCabn9hxWfbuHS573x+r0dJMkkzThEa7pbrcDWK+9zu3e7aBOouf+rQAciqPFMnxwr0aWgKg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1364,6 +1364,12 @@
         "fflate": "~0.8.2",
         "meshoptimizer": "~0.18.1"
       }
+    },
+    "node_modules/@types/three/node_modules/@dimforge/rapier3d-compat": {
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/@dimforge/rapier3d-compat/-/rapier3d-compat-0.12.0.tgz",
+      "integrity": "sha512-uekIGetywIgopfD97oDL5PfeezkFpNhwlzlaEYNOA0N6ghdsOvh/HYjSMek5Q2O1PYvRSDFcqFVJl4r4ZBwOow==",
+      "license": "Apache-2.0"
     },
     "node_modules/@types/webxr": {
       "version": "0.5.22",
@@ -4978,12 +4984,12 @@
       "license": "MIT"
     },
     "node_modules/next": {
-      "version": "15.3.3",
-      "resolved": "https://registry.npmjs.org/next/-/next-15.3.3.tgz",
-      "integrity": "sha512-JqNj29hHNmCLtNvd090SyRbXJiivQ+58XjCcrC50Crb5g5u2zi7Y2YivbsEfzk6AtVI80akdOQbaMZwWB1Hthw==",
+      "version": "15.3.4",
+      "resolved": "https://registry.npmjs.org/next/-/next-15.3.4.tgz",
+      "integrity": "sha512-mHKd50C+mCjam/gcnwqL1T1vPx/XQNFlXqFIVdgQdVAFY9iIQtY0IfaVflEYzKiqjeA7B0cYYMaCrmAYFjs4rA==",
       "license": "MIT",
       "dependencies": {
-        "@next/env": "15.3.3",
+        "@next/env": "15.3.4",
         "@swc/counter": "0.1.3",
         "@swc/helpers": "0.5.15",
         "busboy": "1.6.0",
@@ -4998,14 +5004,14 @@
         "node": "^18.18.0 || ^19.8.0 || >= 20.0.0"
       },
       "optionalDependencies": {
-        "@next/swc-darwin-arm64": "15.3.3",
-        "@next/swc-darwin-x64": "15.3.3",
-        "@next/swc-linux-arm64-gnu": "15.3.3",
-        "@next/swc-linux-arm64-musl": "15.3.3",
-        "@next/swc-linux-x64-gnu": "15.3.3",
-        "@next/swc-linux-x64-musl": "15.3.3",
-        "@next/swc-win32-arm64-msvc": "15.3.3",
-        "@next/swc-win32-x64-msvc": "15.3.3",
+        "@next/swc-darwin-arm64": "15.3.4",
+        "@next/swc-darwin-x64": "15.3.4",
+        "@next/swc-linux-arm64-gnu": "15.3.4",
+        "@next/swc-linux-arm64-musl": "15.3.4",
+        "@next/swc-linux-x64-gnu": "15.3.4",
+        "@next/swc-linux-x64-musl": "15.3.4",
+        "@next/swc-win32-arm64-msvc": "15.3.4",
+        "@next/swc-win32-x64-msvc": "15.3.4",
         "sharp": "^0.34.1"
       },
       "peerDependencies": {

--- a/package.json
+++ b/package.json
@@ -9,29 +9,29 @@
     "lint": "next lint"
   },
   "dependencies": {
-    "@dimforge/rapier3d-compat": "^0.12.0",
+    "@dimforge/rapier3d-compat": "^0.17.3",
     "@react-spring/three": "^10.0.1",
     "@react-three/cannon": "^6.6.0",
-    "@react-three/drei": "^10.2.0",
-    "@react-three/fiber": "latest",
+    "@react-three/drei": "^10.3.0",
+    "@react-three/fiber": "9.1.2",
     "@react-three/postprocessing": "^3.0.4",
     "cannon-es": "^0.20.0",
     "framer-motion": "^12.18.1",
     "framer-motion-3d": "^12.4.13",
-    "meyda": "latest",
-    "next": "latest",
+    "meyda": "5.6.3",
+    "next": "15.3.4",
     "postprocessing": "^6.37.4",
-    "react": "latest",
-    "react-dom": "latest",
+    "react": "19.1.0",
+    "react-dom": "19.1.0",
     "three": "^0.177.0",
-    "tone": "latest",
+    "tone": "15.1.22",
     "zustand": "^5.0.5"
   },
   "devDependencies": {
-    "@types/node": "latest",
-    "@types/react": "latest",
+    "@types/node": "24.0.3",
+    "@types/react": "19.1.8",
     "eslint": "^9.29.0",
     "eslint-config-next": "^15.3.4",
-    "typescript": "latest"
+    "typescript": "5.8.3"
   }
 }


### PR DESCRIPTION
## Summary
- specify exact versions for packages previously set to "latest"
- upgrade outdated packages as reported by `npm outdated`
- regenerate package-lock

## Testing
- `npx tsc --noEmit`
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68572cb1c2ec83268e4727fe17a9b016