### PR TITLE
Fix WebGPU crash and add regression test

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18,6 +18,7 @@
         "framer-motion": "^12.18.1",
         "meyda": "5.6.3",
         "next": "15.3.4",
+        "playwright": "^1.53.1",
         "postprocessing": "^6.37.4",
         "react": "19.1.0",
         "react-dom": "19.1.0",
@@ -3797,6 +3798,20 @@
         }
       }
     },
+    "node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
     "node_modules/function-bind": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
@@ -5275,6 +5290,36 @@
         "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
+    "node_modules/playwright": {
+      "version": "1.53.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.53.1.tgz",
+      "integrity": "sha512-LJ13YLr/ocweuwxyGf1XNFWIU4M2zUSo149Qbp+A4cpwDjsxRPj7k6H25LBrEHiEwxvRbD8HdwvQmRMSvquhYw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.53.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.53.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.53.1.tgz",
+      "integrity": "sha512-Z46Oq7tLAyT0lGoFx4DOuB1IA9D1TPj0QkYxpPVUnGDqHHvDpCftu1J2hM2PiWsNMoZh8+LQaarAWcDfPBc6zg==",
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/possible-typed-array-names": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/possible-typed-array-names/-/possible-typed-array-names-1.1.0.tgz",
@@ -5424,16 +5469,6 @@
       "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/react-merge-refs": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/react-merge-refs/-/react-merge-refs-2.1.1.tgz",
-      "integrity": "sha512-jLQXJ/URln51zskhgppGJ2ub7b2WFKGq3cl3NYKtlHoTG+dN2q7EzWrn3hN3EgPsTMvpR9tpq5ijdp7YwFZkag==",
-      "license": "MIT",
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/gregberge"
-      }
     },
     "node_modules/react-reconciler": {
       "version": "0.31.0",

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
     "dev": "next dev --turbopack",
     "build": "next build",
     "start": "next start",
-    "lint": "next lint"
+    "lint": "next lint",
+    "test": "node tests/regression.js"
   },
   "dependencies": {
     "@dimforge/rapier3d-compat": "^0.17.3",
@@ -19,6 +20,7 @@
     "framer-motion": "^12.18.1",
     "meyda": "5.6.3",
     "next": "15.3.4",
+    "playwright": "^1.53.1",
     "postprocessing": "^6.37.4",
     "react": "19.1.0",
     "react-dom": "19.1.0",

--- a/src/components/SceneCanvas.tsx
+++ b/src/components/SceneCanvas.tsx
@@ -23,9 +23,6 @@ import { getFrequencyBands } from '../lib/analyser'
 import { isLowPowerDevice } from '../lib/performance'
 
 function createRenderer({ canvas, ...props }: any) {
-  if (typeof navigator !== 'undefined' && 'gpu' in navigator) {
-    return new WebGPURenderer({ canvas, ...props })
-  }
   return new THREE.WebGLRenderer({ canvas, ...props })
 }
 

--- a/tests/regression.js
+++ b/tests/regression.js
@@ -1,0 +1,29 @@
+const { chromium } = require('playwright');
+const { spawn } = require('child_process');
+
+(async () => {
+  const server = spawn('npm', ['start'], { stdio: 'inherit' });
+
+  await new Promise(r => setTimeout(r, 3000));
+
+  const browser = await chromium.launch();
+  const page = await browser.newPage();
+  const errors = [];
+  page.on('pageerror', err => errors.push(err.message));
+  page.on('console', msg => {
+    if (msg.type() === 'error') errors.push(msg.text());
+  });
+
+  await page.goto('http://localhost:3000');
+  await page.waitForTimeout(1000);
+  await browser.close();
+
+  server.kill();
+
+  if (errors.some(e => e.includes('maxVertexTextures'))) {
+    console.error('Found maxVertexTextures error:', errors);
+    process.exit(1);
+  } else {
+    console.log('No maxVertexTextures error detected.');
+  }
+})();


### PR DESCRIPTION
## Summary
- ensure SceneCanvas always uses `WebGLRenderer`
- add Playwright regression script

## Testing
- `npx tsc --noEmit`
- `npm run lint`
- `npm run build`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_685736c1a3d08326b2faeaeffc503dcf