### PR TITLE
Add safe stringify utility

### DIFF
--- a/src/lib/safeStringify.ts
+++ b/src/lib/safeStringify.ts
@@ -1,0 +1,10 @@
+export function safeStringify(obj: unknown) {
+  const seen = new WeakSet();
+  return JSON.stringify(obj, (key, value) => {
+    if (typeof value === 'object' && value !== null) {
+      if (seen.has(value)) return;
+      seen.add(value);
+    }
+    return value;
+  });
+}

--- a/src/plugins/PluginManager.ts
+++ b/src/plugins/PluginManager.ts
@@ -3,12 +3,14 @@ export interface Plugin {
   init: (context: any) => void
 }
 
+import { safeStringify } from '../lib/safeStringify'
+
 class PluginManager {
   private plugins: Plugin[] = []
   registerPlugin(plugin: Plugin) {
     this.plugins.push(plugin)
     plugin.init({})
-    console.log(`Plugin ${plugin.name} loaded`)
+    console.log(`Plugin loaded: ${safeStringify(plugin)}`)
   }
 }
 


### PR DESCRIPTION
## Summary
- implement `safeStringify` helper in `src/lib`
- log plugin objects safely

## Testing
- `npx tsc --noEmit` *(fails: numerous errors)*
- `npm run lint`
- `npm run build`
- `npx next start`

------
https://chatgpt.com/codex/tasks/task_e_68574bbf93b88326859376f858a20c86