### PR TITLE
Improve error boundary clarity

### DIFF
--- a/src/components/ErrorBoundary.tsx
+++ b/src/components/ErrorBoundary.tsx
@@ -7,6 +7,7 @@ interface Props {
 }
 interface State {
   hasError: boolean
+  cyclic?: boolean
 }
 
 class ErrorBoundary extends React.Component<Props, State> {
@@ -15,8 +16,9 @@ class ErrorBoundary extends React.Component<Props, State> {
     this.state = { hasError: false }
   }
 
-  static getDerivedStateFromError(_: Error): State {
-    return { hasError: true }
+  static getDerivedStateFromError(error: Error): State {
+    const cyclic = error.message?.includes('cyclic object value')
+    return { hasError: true, cyclic }
   }
 
   componentDidCatch(error: Error, errorInfo: ErrorInfo) {
@@ -27,7 +29,9 @@ class ErrorBoundary extends React.Component<Props, State> {
     if (this.state.hasError) {
       return (
         <div className={ui.glass} style={{ padding: '1rem', color: 'red' }}>
-          Something went wrong.
+          {this.state.cyclic
+            ? 'Data serialization error—please reload.'
+            : 'Something went wrong.'}
         </div>
       )
     }


### PR DESCRIPTION
## Summary
- mark cyclic serialization errors inside `ErrorBoundary`
- show a clearer message when cyclic JSON errors occur

## Testing
- `npx tsc --noEmit`
- `npm run lint`
- `npm run build`
- `npx next start`

------
https://chatgpt.com/codex/tasks/task_e_68575c7637b88326b45887331a29fda4