### PR TITLE
Add store data type guidelines

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,3 +133,7 @@ npm run build
 
 Afterward, test the production build on both desktop and mobile devices to verify everything works as expected.
 
+## Store Usage
+
+State management uses small zustand stores. Refer to [docs/store-guidelines.md](docs/store-guidelines.md) for permitted data types. Avoid storing Three.js, Tone.js or DOM objects in these stores.
+

--- a/docs/store-guidelines.md
+++ b/docs/store-guidelines.md
@@ -1,0 +1,13 @@
+# Store Usage Guidelines
+
+This project uses [Zustand](https://github.com/pmndrs/zustand) for state management. Stores are kept intentionally lightweight so that they can be serialized and replayed easily. **Only plain primitives and arrays should be persisted.** Complex objects such as Three.js meshes, Tone.js classes, or DOM nodes must never be stored directly.
+
+| Store file | Allowed data types |
+|------------|-------------------|
+| `useAudioSettings.ts` | strings, numbers, and functions to update them |
+| `useEffectSettings.ts` | nested records of numbers and functions |
+| `useLoops.ts` | records of booleans and functions |
+| `useObjects.ts` | arrays of objects with primitive fields and functions |
+| `usePerformance.ts` | booleans and functions |
+
+When new stores are added, ensure that their state follows the same rule: primitives or arrays only. Use IDs to reference complex objects managed elsewhere.

--- a/src/store/useAudioSettings.ts
+++ b/src/store/useAudioSettings.ts
@@ -1,5 +1,11 @@
 import { create } from 'zustand'
 
+/**
+ * Audio settings store.
+ * Only simple primitives are persisted here to keep the state serializable.
+ * Do not store Three.js, Tone.js or DOM objects.
+ */
+
 export type ScaleType = 'major' | 'minor'
 
 interface AudioSettingsState {

--- a/src/store/useEffectSettings.ts
+++ b/src/store/useEffectSettings.ts
@@ -1,5 +1,11 @@
 import { create } from 'zustand'
 
+/**
+ * Effect settings store.
+ * Stores only plain objects composed of numbers and strings.
+ * Avoid persisting Three.js, Tone.js or DOM instances here.
+ */
+
 export interface EffectParams {
   reverb: number
   delay: number

--- a/src/store/useLoops.ts
+++ b/src/store/useLoops.ts
@@ -1,5 +1,11 @@
 import { create } from 'zustand'
 
+/**
+ * Loop activity store.
+ * Only primitive flags are stored here.
+ * Never persist Tone.js objects or DOM elements.
+ */
+
 interface LoopState {
   active: Record<string, boolean>
   start: (id: string) => void

--- a/src/store/useObjects.ts
+++ b/src/store/useObjects.ts
@@ -2,6 +2,12 @@
 import { create } from 'zustand'
 import { addBody } from "../lib/physics"
 
+/**
+ * Store of musical object metadata.
+ * Only primitive fields and arrays should be stored here.
+ * Complex runtime objects (Three.js, Tone.js, DOM) must be referenced by ID.
+ */
+
 export type ObjectType = 'note' | 'chord' | 'beat' | 'loop'
 export interface MusicalObject {
   id: string

--- a/src/store/usePerformance.ts
+++ b/src/store/usePerformance.ts
@@ -1,5 +1,10 @@
 import { create } from 'zustand'
 
+/**
+ * Performance tuning store.
+ * Contains only primitive values to allow easy serialization.
+ */
+
 interface PerfState {
   instanced: boolean
   lod: boolean


### PR DESCRIPTION
## Summary
- document allowed data types for Zustand stores
- add notes about avoiding complex objects in stores
- update README with a store usage section
- clarify comments in store modules about primitive-only state

## Testing
- `npx tsc --noEmit`
- `npm run lint` *(fails: `next` not found)*
- `npm run build` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6857792883288326bfbd046c941a8932