### PR TITLE
Implement sound trigger helper

### DIFF
--- a/src/components/MusicalObject.tsx
+++ b/src/components/MusicalObject.tsx
@@ -12,7 +12,7 @@ import { usePhysicsStore } from '../lib/physics'
 import * as THREE from 'three'
 import SingleMusicalObject from './SingleMusicalObject'
 import { usePerformance } from '../store/usePerformance'
-import { playNote, playChord, playBeat } from '../lib/audio'
+import { triggerSound } from '../lib/soundTriggers'
 
 // Group objects by type for instanced rendering
 function groupByType(objects: Obj[]) {
@@ -59,9 +59,7 @@ const MusicalObjectInstances: React.FC = () => {
                   onClick={(e) => {
                     e.stopPropagation()
                     select(obj.id)
-                    if (obj.type === 'note') playNote(obj.id)
-                    else if (obj.type === 'chord') playChord(obj.id)
-                    else playBeat(obj.id)
+                    triggerSound(obj.type, obj.id)
                   }}
                 />
               )

--- a/src/components/SingleMusicalObject.tsx
+++ b/src/components/SingleMusicalObject.tsx
@@ -7,7 +7,8 @@ import { useFrame, useThree } from '@react-three/fiber'
 import { useSpring, a } from '@react-spring/three'
 import * as THREE from 'three'
 import * as Tone from 'tone'
-import { playNote, playChord, playBeat, getObjectMeter, getObjectPanner } from '../lib/audio'
+import { getObjectMeter, getObjectPanner } from '../lib/audio'
+import { triggerSound } from '../lib/soundTriggers'
 import { ObjectType } from '../store/useObjects'
 import { objectConfigs } from '../config/objectTypes'
 import ProceduralShape from './ProceduralShape'
@@ -33,9 +34,7 @@ export const SingleMusicalObject: React.FC<MusicalObjectProps> = ({ id, type, po
     userData: { id, type },
     onCollide: () => {
       // play sound when colliding
-      if (type === 'note') playNote(id)
-      if (type === 'chord') playChord(id)
-      if (type === 'beat' || type === 'loop') playBeat(id)
+      triggerSound(type, id)
     }
   }))
 
@@ -104,9 +103,7 @@ export const SingleMusicalObject: React.FC<MusicalObjectProps> = ({ id, type, po
         onClick={(e) => {
           e.stopPropagation()
           if (!moved) select(id)
-          if (type === 'note') playNote(id)
-          if (type === 'chord') playChord(id)
-          if (type === 'beat' || type === 'loop') playBeat(id)
+          triggerSound(type, id)
         }}
         onPointerMissed={() => setDragging(false)}
       >

--- a/src/components/SpawnMenu.tsx
+++ b/src/components/SpawnMenu.tsx
@@ -5,7 +5,7 @@ import { Float, useCursor } from '@react-three/drei'
 import { useThree } from '@react-three/fiber'
 import { useObjects } from '../store/useObjects'
 import { objectConfigs, objectTypes, ObjectType } from '../config/objectTypes'
-import { playNote, playChord, playBeat, startLoop } from '../lib/audio'
+import { triggerSound } from '../lib/soundTriggers'
 import MusicIcon from './MusicIcon'
 import ProceduralButton from './ProceduralButton'
 import { useSpring, a } from '@react-spring/three'
@@ -58,10 +58,7 @@ const MenuItem: React.FC<ItemProps> = ({ type, index }) => {
       camera.position.z,
     ]
     const id = spawn(type, pos)
-    if (type === 'note') playNote(id)
-    else if (type === 'chord') playChord(id)
-    else if (type === 'beat') playBeat(id)
-    else startLoop(id)
+    triggerSound(type, id)
   }
 
   const color = objectConfigs[type].color

--- a/src/lib/soundTriggers.ts
+++ b/src/lib/soundTriggers.ts
@@ -1,0 +1,17 @@
+import { ObjectType } from '../config/objectTypes'
+import { playNote, playChord, playBeat, startLoop } from './audio'
+
+/**
+ * Trigger a sound based on object type.
+ */
+export function triggerSound(type: ObjectType, id: string): void {
+  if (type === 'note') {
+    playNote(id)
+  } else if (type === 'chord') {
+    playChord(id)
+  } else if (type === 'beat') {
+    playBeat(id)
+  } else {
+    startLoop(id)
+  }
+}


### PR DESCRIPTION
## Summary
- add `triggerSound` helper in `src/lib/soundTriggers.ts`
- replace conditional audio logic in SpawnMenu, MusicalObject, and SingleMusicalObject

## Testing
- `npx tsc --noEmit` *(fails: Cannot find module 'react' or its corresponding type declarations)*
- `npm run lint` *(fails: next: not found)*
- `npm run build` *(fails: next: not found)*

------
https://chatgpt.com/codex/tasks/task_e_6857a0b8d31c8326a48168780a4c341d