### PR TITLE
Fix type safety across renderer and components

### DIFF
--- a/src/components/AudioSettingsPanel.tsx
+++ b/src/components/AudioSettingsPanel.tsx
@@ -1,6 +1,6 @@
 "use client";
 import React, { useEffect, useState, useRef } from "react";
-import { motion } from "framer-motion";
+import { motion, type PanInfo } from "framer-motion";
 import { useAudioSettings, ScaleType } from "../store/useAudioSettings";
 import { setMasterVolume } from "../lib/audio";
 import { usePerformance } from "../store/usePerformance";
@@ -19,7 +19,10 @@ const AudioSettingsPanel: React.FC = () => {
     setMasterVolume(volume);
   }, [volume]);
 
-  const handleDrag = (_: any, info: any) => {
+  const handleDrag = (
+    _: MouseEvent | TouchEvent | PointerEvent,
+    info: PanInfo
+  ) => {
     const rect = dialRef.current?.getBoundingClientRect();
     if (!rect) return;
     const cx = rect.left + rect.width / 2;

--- a/src/components/MusicIcon.tsx
+++ b/src/components/MusicIcon.tsx
@@ -1,7 +1,10 @@
 import React from 'react'
 import { Text3D } from '@react-three/drei'
+import type { FontData } from '@react-three/drei'
 import { ObjectType, objectConfigs } from '../config/objectTypes'
-import font from '../../public/fonts/NotoMusic.json'
+import fontJson from '../../public/fonts/NotoMusic.json'
+
+const font = fontJson as unknown as FontData
 
 interface MusicIconProps {
   type: ObjectType
@@ -12,7 +15,7 @@ interface MusicIconProps {
 const MusicIcon: React.FC<MusicIconProps> = ({ type, size = 0.6, height = 0.1 }) => {
   const cfg = objectConfigs[type]
   return (
-    <Text3D font={font as any} size={size} height={height} bevelEnabled bevelSize={0.02}>
+    <Text3D font={font} size={size} height={height} bevelEnabled bevelSize={0.02}>
       {cfg.icon}
       <meshStandardMaterial color={cfg.color} emissive={cfg.color} />
     </Text3D>

--- a/src/components/MusicalObject.tsx
+++ b/src/components/MusicalObject.tsx
@@ -53,7 +53,7 @@ const MusicalObjectInstances: React.FC = () => {
                 <Instance
                   key={obj.id}
                   color={objectConfigs[t].color}
-                  position={pos as any}
+                  position={pos}
                   rotation={rot}
                   scale={objectConfigs[t].baseScale}
                   onClick={(e) => {

--- a/src/components/ParticleBurst.tsx
+++ b/src/components/ParticleBurst.tsx
@@ -2,7 +2,10 @@
 import React, { useEffect, useRef, useImperativeHandle, forwardRef } from 'react'
 import { useThree, useFrame } from '@react-three/fiber'
 import * as THREE from 'three'
-import { GPUComputationRenderer } from 'three/examples/jsm/misc/GPUComputationRenderer'
+import {
+  GPUComputationRenderer,
+  type Variable,
+} from 'three/examples/jsm/misc/GPUComputationRenderer'
 import { beatBus } from '../lib/events'
 
 export interface ParticleBurstProps {
@@ -71,8 +74,8 @@ const ParticleBurst = forwardRef<ParticleBurstHandle, ParticleBurstProps>(
     const { gl } = useThree()
     const size = Math.ceil(Math.sqrt(count))
     const gpu = useRef<GPUComputationRenderer | null>(null)
-    const posVar = useRef<any>(null)
-    const velVar = useRef<any>(null)
+    const posVar = useRef<Variable | null>(null)
+    const velVar = useRef<Variable | null>(null)
     const meshRef = useRef<THREE.Points>(null)
 
     const burst = () => {

--- a/src/components/SceneCanvas.tsx
+++ b/src/components/SceneCanvas.tsx
@@ -4,6 +4,7 @@ import { Canvas, useThree, useFrame } from '@react-three/fiber'
 import { Physics } from '@react-three/rapier'
 import { AdaptiveDpr } from '@react-three/drei'
 import * as THREE from 'three'
+import type { WebGLRendererParameters } from 'three'
 import FloatingSphere from './FloatingSphere'
 import AudioVisualizer from './AudioVisualizer'
 import Floor from './Floor'
@@ -21,7 +22,7 @@ import type { BloomEffect } from 'postprocessing'
 import { getFrequencyBands } from '../lib/analyser'
 import { isLowPowerDevice } from '../lib/performance'
 
-function createRenderer({ canvas, ...props }: any) {
+function createRenderer({ canvas, ...props }: WebGLRendererParameters) {
   return new THREE.WebGLRenderer({ canvas, ...props })
 }
 

--- a/src/plugins/PluginManager.ts
+++ b/src/plugins/PluginManager.ts
@@ -1,6 +1,8 @@
+export interface PluginContext {}
+
 export interface Plugin {
   name: string
-  init: (context: any) => void
+  init: (context: PluginContext) => void
 }
 
 import { safeStringify } from '../lib/safeStringify'


### PR DESCRIPTION
## Summary
- tighten renderer typing using `WebGLRendererParameters`
- use GPUComputationRenderer `Variable` refs in `ParticleBurst`
- apply explicit typing to font data and handler events
- remove `any` cast from `MusicalObject`
- define `PluginContext` for plugin system

## Testing
- `npx tsc --noEmit`
- `npm run lint`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6857aaa458d083269d66cdfbe5ba2644