### PR TITLE
Add config constants and refactor uses

### DIFF
--- a/src/components/Floor.tsx
+++ b/src/components/Floor.tsx
@@ -2,16 +2,17 @@
 // src/components/Floor.tsx
 import React from 'react'
 import { RigidBody, CuboidCollider } from '@react-three/rapier'
+import { FLOOR_COLLIDER, FLOOR_SIZE } from '../config/constants'
 
 // Static floor for physics bodies to land on
 const Floor: React.FC = () => {
   return (
     <RigidBody type="fixed" colliders={false} rotation={[-Math.PI / 2, 0, 0]}>
       <mesh receiveShadow>
-        <planeGeometry args={[50, 50]} />
+        <planeGeometry args={[FLOOR_SIZE, FLOOR_SIZE]} />
         <meshStandardMaterial color="#111" />
       </mesh>
-      <CuboidCollider args={[25, 0.05, 25]} />
+      <CuboidCollider args={FLOOR_COLLIDER} />
     </RigidBody>
   )
 }

--- a/src/components/ParticleBurst.tsx
+++ b/src/components/ParticleBurst.tsx
@@ -7,6 +7,7 @@ import {
   type Variable,
 } from 'three/examples/jsm/misc/GPUComputationRenderer'
 import { beatBus } from '../lib/events'
+import { PARTICLE_COUNT_HIGH } from '../config/constants'
 
 export interface ParticleBurstProps {
   count?: number
@@ -70,7 +71,7 @@ const renderFragment = /* glsl */`
 `
 
 const ParticleBurst = forwardRef<ParticleBurstHandle, ParticleBurstProps>(
-  ({ count = 1024, color = '#ff88aa' }, ref) => {
+  ({ count = PARTICLE_COUNT_HIGH, color = '#ff88aa' }, ref) => {
     const { gl } = useThree()
     const size = Math.ceil(Math.sqrt(count))
     const gpu = useRef<GPUComputationRenderer | null>(null)

--- a/src/components/PortalRing.tsx
+++ b/src/components/PortalRing.tsx
@@ -5,6 +5,7 @@ import { Float } from '@react-three/drei'
 import type { Mesh } from 'three'
 import { usePortalRing } from './usePortalRing'
 import { playNote } from '../lib/audio'
+import { PORTAL_RADIUS } from '../config/constants'
 
 
 // Portal definitions: assign a musical note and color to each
@@ -41,7 +42,7 @@ const Portal: React.FC<{
         onClick={() => onClick(note)}
       >
         {/* Sphere radius = 2 scene units */}
-        <sphereGeometry args={[2, 32, 32]} />
+        <sphereGeometry args={[PORTAL_RADIUS, 32, 32]} />
         <meshStandardMaterial
           color={color}
           emissive={color}

--- a/src/components/ProceduralButton.tsx
+++ b/src/components/ProceduralButton.tsx
@@ -2,6 +2,7 @@
 import React, { useRef } from 'react'
 import { useFrame } from '@react-three/fiber'
 import * as THREE from 'three'
+import { PLANE_SIZE } from '../config/constants'
 
 interface ProceduralButtonProps {
   position?: [number, number, number]
@@ -37,8 +38,8 @@ const ProceduralButton: React.FC<ProceduralButtonProps> = ({
   })
 
   return (
-    <mesh position={position} rotation={[-Math.PI / 2, 0, 0]}> 
-      <planeGeometry args={[1, 1]} />
+    <mesh position={position} rotation={[-Math.PI / 2, 0, 0]}>
+      <planeGeometry args={[PLANE_SIZE, PLANE_SIZE]} />
       <shaderMaterial
         ref={mat}
         transparent

--- a/src/components/ProceduralShape.tsx
+++ b/src/components/ProceduralShape.tsx
@@ -5,6 +5,7 @@ import { Billboard } from '@react-three/drei'
 import * as THREE from 'three'
 import { ObjectType, objectConfigs } from '../config/objectTypes'
 import { getAnalyser, getFrequencyBands } from '../lib/analyser'
+import { PLANE_SIZE } from '../config/constants'
 
 interface ProceduralShapeProps {
   type: ObjectType
@@ -32,7 +33,7 @@ const ProceduralShape: React.FC<ProceduralShapeProps> = ({ type }) => {
   return (
     <Billboard>
       <mesh>
-        <planeGeometry args={[1, 1]} />
+        <planeGeometry args={[PLANE_SIZE, PLANE_SIZE]} />
         <shaderMaterial
           ref={mat}
           transparent

--- a/src/components/SceneCanvas.tsx
+++ b/src/components/SceneCanvas.tsx
@@ -21,6 +21,12 @@ import { EffectComposer, Bloom } from '@react-three/postprocessing'
 import type { BloomEffect } from 'postprocessing'
 import { getFrequencyBands } from '../lib/analyser'
 import { isLowPowerDevice } from '../lib/performance'
+import {
+  FOV_MIN,
+  FOV_MAX,
+  PARTICLE_COUNT_HIGH,
+  PARTICLE_COUNT_LOW,
+} from '../config/constants'
 
 function createRenderer({ canvas, ...props }: WebGLRendererParameters) {
   return new THREE.WebGLRenderer({ canvas, ...props })
@@ -59,7 +65,7 @@ const SceneCanvas: React.FC = () => {
   const [fov, setFov] = useState(50)
   const containerRef = useRef<HTMLDivElement>(null)
   const [lowPower] = useState<boolean>(isLowPowerDevice())
-  const particleCount = lowPower ? 256 : 1024
+  const particleCount = lowPower ? PARTICLE_COUNT_LOW : PARTICLE_COUNT_HIGH
 
   useEffect(() => {
     initPhysics()
@@ -77,7 +83,7 @@ const SceneCanvas: React.FC = () => {
 
     const handleWheel = (e: WheelEvent) => {
       e.preventDefault()
-      setFov((f) => clamp(f + e.deltaY * 0.05, 30, 100))
+      setFov((f) => clamp(f + e.deltaY * 0.05, FOV_MIN, FOV_MAX))
     }
 
     const pointers = new Map<number, PointerEvent>()
@@ -98,7 +104,7 @@ const SceneCanvas: React.FC = () => {
         const [a, b] = Array.from(pointers.values())
         const dist = Math.hypot(a.clientX - b.clientX, a.clientY - b.clientY)
         const diff = base - dist
-        setFov((f) => clamp(f + diff * 0.1, 30, 100))
+        setFov((f) => clamp(f + diff * 0.1, FOV_MIN, FOV_MAX))
         base = dist
       }
     }

--- a/src/components/ShapeFactory.tsx
+++ b/src/components/ShapeFactory.tsx
@@ -1,18 +1,19 @@
 import React from 'react'
 import { ObjectType, objectConfigs } from '../config/objectTypes'
+import { SHAPE_RADIUS } from '../config/constants'
 
 export function ShapeFactory({ type }: { type: ObjectType }) {
   const geom = objectConfigs[type].geometry
   switch (geom) {
     case 'cube':
-      return <boxGeometry args={[0.5, 0.5, 0.5]} />
+      return <boxGeometry args={[SHAPE_RADIUS, SHAPE_RADIUS, SHAPE_RADIUS]} />
     case 'torus':
-      return <torusGeometry args={[0.5, 0.2, 16, 32]} />
+      return <torusGeometry args={[SHAPE_RADIUS, 0.2, 16, 32]} />
     case 'torusKnot':
-      return <torusKnotGeometry args={[0.5, 0.15, 64, 16]} />
+      return <torusKnotGeometry args={[SHAPE_RADIUS, 0.15, 64, 16]} />
     case 'sphere':
     default:
-      return <sphereGeometry args={[0.5, 32, 32]} />
+      return <sphereGeometry args={[SHAPE_RADIUS, 32, 32]} />
   }
 }
 

--- a/src/components/usePortalRing.tsx
+++ b/src/components/usePortalRing.tsx
@@ -2,6 +2,11 @@
 import { useRef } from 'react'
 import { useFrame, useThree } from '@react-three/fiber'
 import type { Group } from 'three'
+import {
+  PORTAL_RING_MIN_RADIUS,
+  PORTAL_RING_MAX_RADIUS,
+  PORTAL_RING_HEIGHT,
+} from '../config/constants'
 
 export const usePortalRing = (count: number) => {
   const groupRef = useRef<Group>(null!)
@@ -13,8 +18,11 @@ export const usePortalRing = (count: number) => {
     }
   })
 
-  const radius = Math.min(Math.max(viewport.width / 2, 6), 10)
-  const height = 1.5
+  const radius = Math.min(
+    Math.max(viewport.width / 2, PORTAL_RING_MIN_RADIUS),
+    PORTAL_RING_MAX_RADIUS
+  )
+  const height = PORTAL_RING_HEIGHT
 
   const getPosition = (idx: number): [number, number, number] => {
     const angle = (idx / count) * Math.PI * 2

--- a/src/config/constants.ts
+++ b/src/config/constants.ts
@@ -1,0 +1,28 @@
+export const FOV_MIN = 30
+export const FOV_MAX = 100
+
+export const NOTE_ATTACK = 0.05
+export const NOTE_RELEASE = 1
+
+export const CHORD_ATTACK = 0.1
+export const CHORD_RELEASE = 1.5
+
+export const BEAT_PITCH_DECAY = 0.05
+export const BEAT_ATTACK = 0.001
+export const BEAT_DECAY = 0.3
+export const BEAT_SUSTAIN = 0.1
+export const BEAT_RELEASE = 1
+
+export const FLOOR_SIZE = 50
+export const FLOOR_COLLIDER: [number, number, number] = [25, 0.05, 25]
+
+export const PORTAL_RADIUS = 2
+export const PORTAL_RING_MIN_RADIUS = 6
+export const PORTAL_RING_MAX_RADIUS = 10
+export const PORTAL_RING_HEIGHT = 1.5
+
+export const PARTICLE_COUNT_LOW = 256
+export const PARTICLE_COUNT_HIGH = 1024
+
+export const PLANE_SIZE = 1
+export const SHAPE_RADIUS = 0.5

--- a/src/lib/audio.ts
+++ b/src/lib/audio.ts
@@ -6,6 +6,17 @@ import { ObjectType } from '../store/useObjects'
 import { useLoops } from '../store/useLoops'
 
 import { beatBus } from "./events"
+import {
+  NOTE_ATTACK,
+  NOTE_RELEASE,
+  CHORD_ATTACK,
+  CHORD_RELEASE,
+  BEAT_PITCH_DECAY,
+  BEAT_ATTACK,
+  BEAT_DECAY,
+  BEAT_SUSTAIN,
+  BEAT_RELEASE,
+} from '../config/constants'
 // Synth instances (initialized once)
 let noteSynth: Tone.Synth
 let chordSynth: Tone.PolySynth
@@ -40,19 +51,19 @@ async function initAudioEngine() {
   // Single-note synth
   noteSynth = new Tone.Synth().connect(masterVolumeNode)
   noteSynth.oscillator.type = 'sine'
-  noteSynth.envelope.attack = 0.05
-  noteSynth.envelope.release = 1
+  noteSynth.envelope.attack = NOTE_ATTACK
+  noteSynth.envelope.release = NOTE_RELEASE
   // Polyphonic chord synth
   chordSynth = new Tone.PolySynth(Tone.Synth).connect(masterVolumeNode)
   chordSynth.set({ oscillator: { type: 'triangle' } })
-  chordSynth.set({ envelope: { attack: 0.1, release: 1.5 } })
+  chordSynth.set({ envelope: { attack: CHORD_ATTACK, release: CHORD_RELEASE } })
   // Drum synth
   beatSynth = new Tone.MembraneSynth().connect(masterVolumeNode)
-  beatSynth.pitchDecay = 0.05
-  beatSynth.envelope.attack = 0.001
-  beatSynth.envelope.decay = 0.3
-  beatSynth.envelope.sustain = 0.1
-  beatSynth.envelope.release = 1
+  beatSynth.pitchDecay = BEAT_PITCH_DECAY
+  beatSynth.envelope.attack = BEAT_ATTACK
+  beatSynth.envelope.decay = BEAT_DECAY
+  beatSynth.envelope.sustain = BEAT_SUSTAIN
+  beatSynth.envelope.release = BEAT_RELEASE
   audioInitialized = true
 }
 


### PR DESCRIPTION
## Summary
- centralize repeated numeric values in `src/config/constants.ts`
- use the new constants in SceneCanvas, ParticleBurst and Portal components
- update Procedural shapes and floor sizing to reference constants
- expose envelope defaults via constants in audio engine

## Testing
- `npx tsc --noEmit`
- `npm run lint`
- `npm run build`
- `npx next start`

------
https://chatgpt.com/codex/tasks/task_e_6857ae19bf5c83269ead0b4a207be956