### PR TITLE
Add explicit typings to stores and set jsx

### DIFF
--- a/src/store/useEffectSettings.ts
+++ b/src/store/useEffectSettings.ts
@@ -31,7 +31,7 @@ interface EffectState {
 export const useEffectSettings = create<EffectState>((set, get) => ({
   effects: {},
   selected: null,
-  select: (id) => {
+  select: (id: string | null) => {
     if (id === null) return set({ selected: null })
     const effects = get().effects
     if (!effects[id]) {
@@ -40,12 +40,12 @@ export const useEffectSettings = create<EffectState>((set, get) => ({
       set({ selected: id })
     }
   },
-  setEffect: (id, params) =>
+  setEffect: (id: string, params: Partial<EffectParams>) =>
     set((state) => ({
       effects: {
         ...state.effects,
         [id]: { ...(state.effects[id] || defaultEffectParams), ...params },
       },
     })),
-  getParams: (id) => get().effects[id] || defaultEffectParams,
+  getParams: (id: string) => get().effects[id] || defaultEffectParams,
 }))

--- a/src/store/useLoops.ts
+++ b/src/store/useLoops.ts
@@ -14,8 +14,8 @@ interface LoopState {
 
 export const useLoops = create<LoopState>((set) => ({
   active: {},
-  start: (id) => set((s) => ({ active: { ...s.active, [id]: true } })),
-  stop: (id) =>
+  start: (id: string) => set((s) => ({ active: { ...s.active, [id]: true } })),
+  stop: (id: string) =>
     set((s) => {
       const { [id]: _, ...rest } = s.active
       return { active: rest }

--- a/src/store/useObjects.ts
+++ b/src/store/useObjects.ts
@@ -25,7 +25,7 @@ interface ObjectState {
 
 export const useObjects = create<ObjectState>((set, get) => ({
   objects: [],
-  spawn: (type, position) => {
+  spawn: (type: ObjectType, position?: [number, number, number]) => {
     const id = Date.now().toString()
     const newObj: MusicalObject = {
       id,

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -16,7 +16,7 @@
     "moduleResolution": "node",
     "resolveJsonModule": true,
     "isolatedModules": true,
-    "jsx": "preserve",
+    "jsx": "react-jsx",
     "incremental": true,
     "baseUrl": ".",
     "paths": {


### PR DESCRIPTION
## Summary
- explicitly type store functions
- set `jsx` compiler option to `react-jsx`

## Testing
- `npx tsc --noEmit`
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6857b167e5a883269d96e031bfc2b8bf