### PR TITLE
Add safeStringify to logging and docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,6 +133,16 @@ npm run build
 
 Afterward, test the production build on both desktop and mobile devices to verify everything works as expected.
 
+## Logging
+
+When printing objects to the console or persisting debugging data, use the helper `safeStringify` found in `src/lib/safeStringify.ts`. It gracefully handles class instances and circular references.
+
+```ts
+import { safeStringify } from '@/lib/safeStringify'
+
+console.log(safeStringify(myObject))
+```
+
 ## Store Usage
 
 State management uses small zustand stores. Refer to [docs/store-guidelines.md](docs/store-guidelines.md) for permitted data types. Avoid storing Three.js, Tone.js or DOM objects in these stores.

--- a/src/components/ErrorBoundary.tsx
+++ b/src/components/ErrorBoundary.tsx
@@ -1,6 +1,7 @@
 'use client'
 import React, { ErrorInfo, ReactNode } from 'react'
 import ui from '../styles/ui.module.css'
+import { safeStringify } from '../lib/safeStringify'
 
 interface Props {
   children: ReactNode
@@ -22,7 +23,11 @@ class ErrorBoundary extends React.Component<Props, State> {
   }
 
   componentDidCatch(error: Error, errorInfo: ErrorInfo) {
-    console.error('ErrorBoundary caught an error', error, errorInfo)
+    console.error(
+      'ErrorBoundary caught an error',
+      safeStringify(error),
+      safeStringify(errorInfo)
+    )
   }
 
   render() {

--- a/src/components/ParticleBurst.tsx
+++ b/src/components/ParticleBurst.tsx
@@ -8,6 +8,7 @@ import {
 } from 'three/examples/jsm/misc/GPUComputationRenderer'
 import { beatBus } from '../lib/events'
 import { PARTICLE_COUNT_HIGH } from '../config/constants'
+import { safeStringify } from '../lib/safeStringify'
 
 export interface ParticleBurstProps {
   count?: number
@@ -108,7 +109,7 @@ const ParticleBurst = forwardRef<ParticleBurstHandle, ParticleBurstProps>(
       velVar.current.material.uniforms.burst = { value: 0 }
       posVar.current.material.uniforms.delta = { value: 0 }
       const err = compute.init()
-      if (err) console.error(err)
+      if (err) console.error(safeStringify(err))
       gpu.current = compute
     }, [gl, size])
 


### PR DESCRIPTION
## Summary
- log errors with `safeStringify` in `ErrorBoundary`
- log GPU init errors with `safeStringify`
- document the new helper in README

## Testing
- `npm run lint`
- `npx tsc --noEmit`
- `npm run build`
- `npx next start`

------
https://chatgpt.com/codex/tasks/task_e_68584700cb1c8326a619fdd43e6a97e9