### PR TITLE
Fix client directive

### DIFF
--- a/src/components/AudioVisualizer.tsx
+++ b/src/components/AudioVisualizer.tsx
@@ -1,3 +1,4 @@
+'use client'
 // src/components/AudioVisualizer.tsx
 import React, { useRef, useEffect } from 'react'
 import { useFrame, useThree } from '@react-three/fiber'

--- a/src/components/MusicIcon.tsx
+++ b/src/components/MusicIcon.tsx
@@ -1,3 +1,4 @@
+'use client'
 import React from 'react'
 import { Text3D } from '@react-three/drei'
 import type { FontData } from '@react-three/drei'

--- a/src/components/PortalRing.tsx
+++ b/src/components/PortalRing.tsx
@@ -1,3 +1,4 @@
+'use client'
 // src/components/PortalRing.tsx
 import React, { useRef } from 'react'
 import { useFrame } from '@react-three/fiber'

--- a/src/components/ShapeFactory.tsx
+++ b/src/components/ShapeFactory.tsx
@@ -1,3 +1,4 @@
+'use client'
 import React from 'react'
 import { ObjectType, objectConfigs } from '../config/objectTypes'
 import { SHAPE_RADIUS } from '../config/constants'


### PR DESCRIPTION
## Summary
- add `'use client'` to R3F components for client-only execution

## Testing
- `npx tsc --noEmit`
- `npm run lint`
- `npm run build`
- `npx next start`

------
https://chatgpt.com/codex/tasks/task_e_685851ce82908326b7bc6b9e33498cf9