### PR TITLE
Fix cyclic serialization logging

### DIFF
--- a/src/components/ErrorBoundary.tsx
+++ b/src/components/ErrorBoundary.tsx
@@ -25,8 +25,8 @@ class ErrorBoundary extends React.Component<Props, State> {
   componentDidCatch(error: Error, errorInfo: ErrorInfo) {
     console.error(
       'ErrorBoundary caught an error',
-      safeStringify(error),
-      safeStringify(errorInfo)
+      error.message,
+      errorInfo.componentStack
     )
   }
 


### PR DESCRIPTION
## Summary
- avoid serializing the entire error object in `ErrorBoundary`

## Testing
- `npx tsc --noEmit`
- `npm run lint`
- `npm run build`
- `npx next start` *(fails: EADDRINUSE)*

------
https://chatgpt.com/codex/tasks/task_e_6857b3cca6ac8326ba51b255e78a3181