### PR TITLE
Fix audio startup and Tone deprecations

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -11,6 +11,11 @@ module.exports = {
       ...(config.resolve.alias || {}),
       '@': path.resolve(__dirname, 'src'),
     };
+    config.module = config.module || { rules: [] }
+    config.module.rules.push({
+      test: /\.js\.map$/,
+      use: 'null-loader'
+    })
     return config;
   },
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -30,6 +30,7 @@
         "@types/react": "19.1.8",
         "eslint": "^9.29.0",
         "eslint-config-next": "^15.3.4",
+        "null-loader": "^4.0.1",
         "typescript": "5.8.3"
       }
     },
@@ -2092,6 +2093,16 @@
         "url": "https://github.com/sponsors/epoberezkin"
       }
     },
+    "node_modules/ajv-keywords": {
+      "version": "3.5.2",
+      "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-3.5.2.tgz",
+      "integrity": "sha512-5p6WTN0DdTGVQk6VjcEju19IgaHudalcfabD7yhDGeA6bcQnmL+CpveLJq/3hvfwd1aof6L386Ougkx6RfyMIQ==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "ajv": "^6.9.1"
+      }
+    },
     "node_modules/ansi-styles": {
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
@@ -2391,6 +2402,16 @@
       "license": "MIT",
       "dependencies": {
         "require-from-string": "^2.0.2"
+      }
+    },
+    "node_modules/big.js": {
+      "version": "5.2.2",
+      "resolved": "https://registry.npmjs.org/big.js/-/big.js-5.2.2.tgz",
+      "integrity": "sha512-vyL2OymJxmarO8gxMr0mhChsO9QGwhynfuu4+MHTAW6czfq9humCB7rKpUjDd9YUiDPU4mzpyupFSvOClAwbmQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "*"
       }
     },
     "node_modules/brace-expansion": {
@@ -2879,6 +2900,16 @@
       "integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/emojis-list": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/emojis-list/-/emojis-list-3.0.0.tgz",
+      "integrity": "sha512-/kyM18EfinwXZbno9FyUGeFh87KC8HRQBQGildHZbEuRyWFOmv1U10o9BBp8XVZDVNNuQKyIGIu5ZYAAXJ0V2Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
+      }
     },
     "node_modules/es-abstract": {
       "version": "1.24.0",
@@ -4730,6 +4761,34 @@
         "immediate": "~3.0.5"
       }
     },
+    "node_modules/loader-utils": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-2.0.4.tgz",
+      "integrity": "sha512-xXqpXoINfFhgua9xiqD8fPFHgkoq1mmmpE92WlDbm9rNRd/EbRb+Gqf908T2DMfuHjjJlksiK2RbHVOdD/MqSw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "big.js": "^5.2.2",
+        "emojis-list": "^3.0.0",
+        "json5": "^2.1.2"
+      },
+      "engines": {
+        "node": ">=8.9.0"
+      }
+    },
+    "node_modules/loader-utils/node_modules/json5": {
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
+      "integrity": "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "json5": "lib/cli.js"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/locate-path": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
@@ -5013,6 +5072,27 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.6.0"
+      }
+    },
+    "node_modules/null-loader": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/null-loader/-/null-loader-4.0.1.tgz",
+      "integrity": "sha512-pxqVbi4U6N26lq+LmgIbB5XATP0VdZKOG25DhHi8btMmJJefGArFyDg1yc4U3hWCJbMqSrw0qyrz1UQX+qYXqg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "loader-utils": "^2.0.0",
+        "schema-utils": "^3.0.0"
+      },
+      "engines": {
+        "node": ">= 10.13.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/webpack"
+      },
+      "peerDependencies": {
+        "webpack": "^4.0.0 || ^5.0.0"
       }
     },
     "node_modules/object-assign": {
@@ -5686,6 +5766,25 @@
       "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.25.0.tgz",
       "integrity": "sha512-xFVuu11jh+xcO7JOAGJNOXld8/TcEHK/4CituBUeUb5hqxJLj9YuemAEuvm9gQ/+pgXYfbQuqAkiYu+u7YEsNA==",
       "license": "MIT"
+    },
+    "node_modules/schema-utils": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-3.3.0.tgz",
+      "integrity": "sha512-pN/yOAvcC+5rQ5nERGuwrjLlYvLTbCibnZ1I7B1LaiAz9BRBlE9GMgE/eqV30P7aJQUf7Ddimy/RsbYO/GrVGg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/json-schema": "^7.0.8",
+        "ajv": "^6.12.5",
+        "ajv-keywords": "^3.5.2"
+      },
+      "engines": {
+        "node": ">= 10.13.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/webpack"
+      }
     },
     "node_modules/semver": {
       "version": "7.7.2",

--- a/package.json
+++ b/package.json
@@ -12,10 +12,10 @@
   "dependencies": {
     "@dimforge/rapier3d-compat": "^0.17.3",
     "@react-spring/three": "^10.0.1",
-    "@react-three/rapier": "^0.12.1",
     "@react-three/drei": "^10.3.0",
     "@react-three/fiber": "9.1.2",
     "@react-three/postprocessing": "^3.0.4",
+    "@react-three/rapier": "^0.12.1",
     "framer-motion": "^12.18.1",
     "meyda": "5.6.3",
     "next": "15.3.4",
@@ -32,6 +32,7 @@
     "@types/react": "19.1.8",
     "eslint": "^9.29.0",
     "eslint-config-next": "^15.3.4",
+    "null-loader": "^4.0.1",
     "typescript": "5.8.3"
   }
 }

--- a/src/components/MusicalObject.tsx
+++ b/src/components/MusicalObject.tsx
@@ -9,6 +9,7 @@ import ShapeFactory from './ShapeFactory'
 import EffectPanel from "./EffectPanel"
 import { useEffectSettings } from '../store/useEffectSettings'
 import { usePhysicsStore } from '../lib/physics'
+import * as Tone from 'tone'
 import * as THREE from 'three'
 import SingleMusicalObject from './SingleMusicalObject'
 import { usePerformance } from '../store/usePerformance'
@@ -56,9 +57,11 @@ const MusicalObjectInstances: React.FC = () => {
                   position={pos}
                   rotation={rot}
                   scale={objectConfigs[t].baseScale}
-                  onClick={(e) => {
+                  onClick={async (e) => {
                     e.stopPropagation()
                     select(obj.id)
+                    await Tone.start()
+                    await Tone.getContext().resume()
                     triggerSound(obj.type, obj.id)
                   }}
                 />

--- a/src/components/PortalRing.tsx
+++ b/src/components/PortalRing.tsx
@@ -6,6 +6,7 @@ import { Float } from '@react-three/drei'
 import type { Mesh } from 'three'
 import { usePortalRing } from './usePortalRing'
 import { playNote } from '../lib/audio'
+import * as Tone from 'tone'
 import { PORTAL_RADIUS } from '../config/constants'
 
 
@@ -68,6 +69,8 @@ const PortalRing: React.FC = () => {
     const now = performance.now()
     if (now - lastClick < 50) return
     lastClick = now
+    await Tone.start()
+    await Tone.getContext().resume()
     await playNote(note)
   }
 

--- a/src/components/SingleMusicalObject.tsx
+++ b/src/components/SingleMusicalObject.tsx
@@ -108,9 +108,11 @@ export const SingleMusicalObject: React.FC<MusicalObjectProps> = ({ id, type, po
           e.stopPropagation()
           setDragging(false)
         }}
-        onClick={(e) => {
+        onClick={async (e) => {
           e.stopPropagation()
           if (!moved) select(id)
+          await Tone.start()
+          await Tone.getContext().resume()
           triggerSound(type, id)
         }}
         onPointerMissed={() => setDragging(false)}

--- a/src/components/SpawnMenu.tsx
+++ b/src/components/SpawnMenu.tsx
@@ -9,6 +9,7 @@ import { triggerSound } from '../lib/soundTriggers'
 import MusicIcon from './MusicIcon'
 import ProceduralButton from './ProceduralButton'
 import { useSpring, a } from '@react-spring/three'
+import * as Tone from 'tone'
 
 interface ItemProps { type: ObjectType; index: number }
 
@@ -49,7 +50,7 @@ const MenuItem: React.FC<ItemProps> = ({ type, index }) => {
     config: { tension: 300, friction: 20 },
   })
 
-  const handlePointerUp = () => {
+  const handlePointerUp = async () => {
     setActive(false)
     setRipple(true)
     const pos: [number, number, number] = [
@@ -58,6 +59,8 @@ const MenuItem: React.FC<ItemProps> = ({ type, index }) => {
       camera.position.z,
     ]
     const id = spawn(type, pos)
+    await Tone.start()
+    await Tone.getContext().resume()
     triggerSound(type, id)
   }
 

--- a/src/lib/audio.ts
+++ b/src/lib/audio.ts
@@ -45,8 +45,7 @@ interface EffectChain {
  */
 async function initAudioEngine() {
   if (audioInitialized) return
-  await Tone.start()
-  masterVolumeNode = new Tone.Volume(0).toDestination()
+  masterVolumeNode = new Tone.Volume({ volume: 0 }).toDestination()
   masterVolumeNode.volume.value = useAudioSettings.getState().volume * 100 - 100
   // Single-note synth
   noteSynth = new Tone.Synth().connect(masterVolumeNode)
@@ -54,7 +53,7 @@ async function initAudioEngine() {
   noteSynth.envelope.attack = NOTE_ATTACK
   noteSynth.envelope.release = NOTE_RELEASE
   // Polyphonic chord synth
-  chordSynth = new Tone.PolySynth(Tone.Synth).connect(masterVolumeNode)
+  chordSynth = new Tone.PolySynth({ voice: Tone.Synth }).connect(masterVolumeNode)
   chordSynth.set({ oscillator: { type: 'triangle' } })
   chordSynth.set({ envelope: { attack: CHORD_ATTACK, release: CHORD_RELEASE } })
   // Drum synth
@@ -77,10 +76,10 @@ function transpose(note: string, key: string) {
 }
 
 function createChain(): EffectChain {
-  const hp = new Tone.Filter(0, 'highpass')
-  const lp = new Tone.Filter(20000, 'lowpass')
-  const delay = new Tone.FeedbackDelay('8n', 0.5)
-  const reverb = new Tone.Reverb(2)
+  const hp = new Tone.Filter({ frequency: 0, type: 'highpass' })
+  const lp = new Tone.Filter({ frequency: 20000, type: 'lowpass' })
+  const delay = new Tone.FeedbackDelay({ delayTime: '8n', feedback: 0.5 })
+  const reverb = new Tone.Reverb({ decay: 2 })
   hp.connect(lp)
   lp.connect(delay)
   delay.connect(reverb)
@@ -92,7 +91,7 @@ function getObjectSynth(id: string, type: ObjectType) {
   if (!os) {
     const chain = createChain()
     let synth: Tone.Synth | Tone.PolySynth | Tone.MembraneSynth
-    if (type === 'chord') synth = new Tone.PolySynth(Tone.Synth)
+    if (type === 'chord') synth = new Tone.PolySynth({ voice: Tone.Synth })
     else if (type === 'beat') synth = new Tone.MembraneSynth()
     else synth = new Tone.Synth()
     const meter = new Tone.Meter({ normalRange: true, smoothing: 0.8 })


### PR DESCRIPTION
## Summary
- ensure Tone.start() and resume happen on user gestures
- refactor deprecated Tone constructors to use options object
- ignore invalid source map URLs via null-loader
- update package lock for null-loader

## Testing
- `npx tsc --noEmit`
- `npm run lint`
- `npm run build`
- `npm run start`

------
https://chatgpt.com/codex/tasks/task_e_6858728809848326a421bc29e6b2f47b