### PR TITLE
Add runtime primitive assertions

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -6,6 +6,7 @@ import React, { useEffect } from 'react'
 import PluginLoader from "./PluginLoader"
 import AudioSettingsPanel from '@/components/AudioSettingsPanel'
 import ErrorBoundary from '@/components/ErrorBoundary'
+import { assertPrimitives } from '@/lib/assertPrimitives'
 
 export default function RootLayout({ children }: { children: React.ReactNode }) {
   useEffect(() => {
@@ -22,6 +23,8 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
       })
     })
   }, [])
+  const pageProps = {}
+  assertPrimitives(pageProps, 'pageProps')
   return (
     <html lang="en">
       <body className={ui.root}>

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,12 +1,21 @@
 "use client";
 import dynamic from "next/dynamic";
 import ZoomHUD from "@/components/ZoomHUD";
+import { useAudioSettings } from "@/store/useAudioSettings";
+import { useObjects } from "@/store/useObjects";
+import { assertPrimitives } from "@/lib/assertPrimitives";
 
 const SceneCanvas = dynamic(() => import("@/components/SceneCanvas"), {
   ssr: false,
 });
 
 const Home = () => {
+  const key = useAudioSettings((s) => s.key);
+  const scale = useAudioSettings((s) => s.scale);
+  const objects = useObjects((s) => s.objects);
+
+  assertPrimitives({ key, scale, objects }, 'pageData');
+
   return (
     <div style={{ height: '100vh', width: '100vw', position: 'relative' }}>
       <SceneCanvas />

--- a/src/lib/assertPrimitives.ts
+++ b/src/lib/assertPrimitives.ts
@@ -1,0 +1,18 @@
+export function assertPrimitives(obj: any, path = 'root') {
+  if (obj && typeof obj === 'object') {
+    for (const [key, val] of Object.entries(obj)) {
+      const current = `${path}.${key}`
+      if (val && typeof val === 'object') {
+        if (Array.isArray(val)) {
+          val.forEach((v, i) => assertPrimitives(v, `${current}[${i}]`))
+        } else if (Object.getPrototypeOf(val) !== Object.prototype) {
+          throw new Error(`\u26d4\ufe0f Non-plain value at ${current}: ${
+            (val as any).constructor.name
+          }`)
+        } else {
+          assertPrimitives(val, current)
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- add `assertPrimitives` utility to detect non-serializable values
- instrument `app/layout.tsx` and `app/page.tsx` with primitive checks

## Testing
- `npx tsc --noEmit`
- `npm run lint`
- `npm run build`
- `npx next start`

------
https://chatgpt.com/codex/tasks/task_e_6858a50549a883268bb070964b7f2ca7