### PR TITLE
Fix console error serialization

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -3,6 +3,7 @@
 import '../src/styles/globals.css'
 import ui from '../src/styles/ui.module.css'
 import React, { useEffect } from 'react'
+import { safeStringify } from '../src/lib/safeStringify'
 import PluginLoader from "./PluginLoader"
 import AudioSettingsPanel from '@/components/AudioSettingsPanel'
 import ErrorBoundary from '@/components/ErrorBoundary'
@@ -10,6 +11,14 @@ import { assertPrimitives } from '@/lib/assertPrimitives'
 
 export default function RootLayout({ children }: { children: React.ReactNode }) {
   useEffect(() => {
+    const orig = console.error
+    console.error = (...args: unknown[]) => {
+      orig(
+        ...args.map((a) =>
+          typeof a === 'string' ? a : safeStringify(a)
+        )
+      )
+    }
     window.onerror = (_msg, _src, lineno, colno, error) => {
       console.error('Global error:', {
         lineno,
@@ -22,6 +31,9 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
         stack: (e as PromiseRejectionEvent).reason?.stack,
       })
     })
+    return () => {
+      console.error = orig
+    }
   }, [])
   const pageProps = {}
   assertPrimitives(pageProps, 'pageProps')


### PR DESCRIPTION
## Summary
- wrap console.error with safe stringification to avoid cyclic logging errors

## Testing
- `npx tsc --noEmit`
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6858cbcee9308326945d57885f8309b0