### PR TITLE
Fix JSON serialization error

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -7,20 +7,27 @@ import PluginLoader from "./PluginLoader"
 import AudioSettingsPanel from '@/components/AudioSettingsPanel'
 import ErrorBoundary from '@/components/ErrorBoundary'
 import { assertPrimitives } from '@/lib/assertPrimitives'
+import { safeStringify } from '@/lib/safeStringify'
 
 export default function RootLayout({ children }: { children: React.ReactNode }) {
   useEffect(() => {
     window.onerror = (_msg, _src, lineno, colno, error) => {
-      console.error('Global error:', {
-        lineno,
-        colno,
-        stack: (error as Error | undefined)?.stack,
-      })
+      console.error(
+        'Global error:',
+        safeStringify({
+          lineno,
+          colno,
+          stack: (error as Error | undefined)?.stack,
+        })
+      )
     }
     window.addEventListener('unhandledrejection', (e) => {
-      console.error('Unhandled rejection:', {
-        stack: (e as PromiseRejectionEvent).reason?.stack,
-      })
+      console.error(
+        'Unhandled rejection:',
+        safeStringify({
+          stack: (e as PromiseRejectionEvent).reason?.stack,
+        })
+      )
     })
   }, [])
   const pageProps = {}

--- a/src/components/ErrorBoundary.tsx
+++ b/src/components/ErrorBoundary.tsx
@@ -23,12 +23,15 @@ class ErrorBoundary extends React.Component<Props, State> {
   }
 
   componentDidCatch(error: Error, errorInfo: ErrorInfo) {
-    console.error('ErrorBoundary caught:', {
-      name: error.name,
-      message: error.message,
-      stack: error.stack,
-      componentStack: errorInfo.componentStack,
-    })
+    console.error(
+      'ErrorBoundary caught:',
+      safeStringify({
+        name: error.name,
+        message: error.message,
+        stack: error.stack,
+        componentStack: errorInfo.componentStack,
+      })
+    )
   }
 
   render() {

--- a/src/lib/safeStringify.ts
+++ b/src/lib/safeStringify.ts
@@ -1,7 +1,20 @@
+/**
+ * Safely stringify an object for logging.
+ * - Removes circular references
+ * - Skips Three.js objects like textures to avoid warnings
+ * - Functions are stringified as their name
+ */
 export function safeStringify(obj: unknown): string {
   const seen = new WeakSet();
   return JSON.stringify(obj, (_k, v) => {
+    if (typeof v === 'function') {
+      return `[Function ${(v as Function).name || 'anonymous'}]`;
+    }
     if (v && typeof v === 'object') {
+      // Skip complex Three.js objects that implement toJSON (e.g., Texture)
+      if ((v as any).isTexture || (v as any).isObject3D || (v as any).isMaterial) {
+        return `[${(v as any).constructor?.name || 'Object'}]`;
+      }
       if (seen.has(v)) return;
       seen.add(v);
     }


### PR DESCRIPTION
## Summary
- improve `safeStringify` helper to skip Three.js objects
- ensure console.error uses safeStringify to avoid Next.js intercept cycles

## Testing
- `npx tsc --noEmit`
- `npm run lint`
- `npm run build`
- `npm test` *(fails: browsers missing)*

------
https://chatgpt.com/codex/tasks/task_e_6858cbcee9308326945d57885f8309b0