### PR TITLE
Fix serialization by asserting primitives

### DIFF
--- a/src/lib/assertPrimitives.ts
+++ b/src/lib/assertPrimitives.ts
@@ -1,14 +1,14 @@
 export function assertPrimitives(obj: any, path = 'root') {
   if (obj && typeof obj === 'object') {
     for (const [key, val] of Object.entries(obj)) {
-      const current = `${path}.${key}`
+      const current = `${path}.${key}`;
       if (val && typeof val === 'object') {
         if (Array.isArray(val)) {
-          val.forEach((v, i) => assertPrimitives(v, `${current}[${i}]`))
+          val.forEach((v, i) => assertPrimitives(v, `${current}[${i}]`));
         } else if (Object.getPrototypeOf(val) !== Object.prototype) {
-          throw new Error(`\u26d4\ufe0f Non-plain value at ${current}: ${(val as any).constructor.name}`)
+          throw new Error(`⛔️ Non-plain value at ${current}: ${val.constructor.name}`);
         } else {
-          assertPrimitives(val, current)
+          assertPrimitives(val, current);
         }
       }
     }


### PR DESCRIPTION
## Summary
- add `assertPrimitives` helper to trace non-primitive props

## Testing
- `npx tsc --noEmit`
- `npm run lint`
- `npm run build`
- `npx next start`

------
https://chatgpt.com/codex/tasks/task_e_6858e8c7ee088326b4b49a50953815ce