### PR TITLE
Run Playwright install before tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,4 +14,13 @@ jobs:
         with:
           node-version: '18'
       - run: npm ci
+      - name: Cache Playwright browsers
+        uses: actions/cache@v3
+        with:
+          path: ~/.cache/ms-playwright
+          key: ${{ runner.os }}-playwright-${{ hashFiles('package-lock.json') }}
+          restore-keys: |
+            ${{ runner.os }}-playwright-
+      - run: npx playwright install
       - run: npx tsc --noEmit
+      - run: npm test

--- a/README.md
+++ b/README.md
@@ -124,11 +124,13 @@ Average FPS on a mid-range laptop:
 
 ## Validation
 
-Before merging changes, ensure the project builds and passes type checking:
+Before merging changes, ensure the project builds, passes type checking, and all tests run:
 
 ```bash
 npx tsc --noEmit
 npm run build
+npx playwright install
+npm test
 ```
 
 Afterward, test the production build on both desktop and mobile devices to verify everything works as expected.


### PR DESCRIPTION
## Summary
- cache Playwright browsers and run `npx playwright install` before `npm test`
- document that browser binaries must be installed before running tests

## Testing
- `npx tsc --noEmit`
- `npm run lint`
- `npm run build`
- `npx playwright install`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_685a22aff4588326bdcd7b6f4bf17d4a