### PR TITLE
Implement random spawn positions

### DIFF
--- a/src/components/ProceduralShapes.tsx
+++ b/src/components/ProceduralShapes.tsx
@@ -16,6 +16,7 @@ const ProceduralShapes: React.FC = () => {
   const analyserRef = useRef<AnalyserNode | null>(null);
   const [dragIndex, setDragIndex] = useState<number | null>(null);
   const positions = useRef<THREE.Vector3[]>([]);
+  const ids = useRef<string[]>([]);
   const { raycaster, mouse, camera } = useThree();
   const plane = useRef(new THREE.Plane(new THREE.Vector3(0, 1, 0), 0));
   const hit = useRef(new THREE.Vector3());
@@ -27,7 +28,13 @@ const ProceduralShapes: React.FC = () => {
   }, []);
 
   useEffect(() => {
-    positions.current = objects.map((o) => new THREE.Vector3(...o.position));
+    const prev = positions.current;
+    const prevIds = ids.current;
+    positions.current = objects.map((o, idx) => {
+      const i = prevIds.indexOf(o.id);
+      return i !== -1 ? prev[i] : new THREE.Vector3(...o.position);
+    });
+    ids.current = objects.map((o) => o.id);
     if (instRef.current) instRef.current.count = objects.length;
   }, [objects]);
 

--- a/src/store/useObjects.ts
+++ b/src/store/useObjects.ts
@@ -30,7 +30,12 @@ export const useObjects = create<ObjectState>((set, get) => ({
     const newObj: MusicalObject = {
       id,
       type,
-      position: position ?? [0, 3, 0],
+      position:
+        position ?? ([
+          Math.random() * 6 - 3,
+          3,
+          Math.random() * 6 - 3,
+        ] as [number, number, number]),
     }
     set({ objects: [...get().objects, newObj] })
     addBody(id, newObj.position)


### PR DESCRIPTION
## Summary
- set random position in `useObjects.spawn`
- preserve object positions when instancing meshes

## Testing
- `npx tsc -p tsconfig.json --noEmit`
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_685a33a704ac832683a74ae1282c93fe