### PR TITLE
Fix sequencer playback

### DIFF
--- a/src/components/SoundInspector.tsx
+++ b/src/components/SoundInspector.tsx
@@ -6,6 +6,8 @@ import * as Tone from "tone";
 import { useEffectSettings, defaultEffectParams } from "@/store/useEffectSettings";
 import { ObjectType } from "@/store/useObjects";
 import { useAudioSettings } from "@/store/useAudioSettings";
+import { triggerSound } from "../lib/soundTriggers";
+import { playNote, playChord, playBeat } from "../lib/audio";
 
 interface Props { objectId: string; type: ObjectType; }
 
@@ -21,9 +23,19 @@ const SoundInspector: React.FC<Props> = ({ objectId, type }) => {
 
   useEffect(() => {
     seqRef.current?.dispose();
-    const callback = (_time: number, step: boolean) => {
+    const callback = async (_time: number, step: boolean) => {
       if (!step) return;
-      if (type === "note") Tone.Transport.scheduleOnce(() => Tone.start(), "+0");
+      await Tone.start();
+      await Tone.getContext().resume();
+      if (type === "note") {
+        playNote(objectId, pitch);
+      } else if (type === "chord") {
+        playChord(objectId);
+      } else if (type === "beat") {
+        playBeat(objectId);
+      } else {
+        triggerSound(type, objectId);
+      }
     };
     const seq = new Tone.Sequence(callback, steps, "16n");
     seq.start(0);
@@ -33,7 +45,7 @@ const SoundInspector: React.FC<Props> = ({ objectId, type }) => {
     return () => {
       seq.dispose();
     };
-  }, [steps, pitch, bpm, type]);
+  }, [steps, pitch, bpm, type, objectId]);
 
   const toggleStep = (i: number) => {
     const newSteps = [...steps];


### PR DESCRIPTION
## Summary
- call Tone.js playback helpers for each active step

## Testing
- `npm run lint`
- `npx tsc --noEmit`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_685a36625a988326ba21837c6870371e