### PR TITLE
Add sequencer and scene refactor

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,11 +55,11 @@ To get started with the project, follow these steps:
 
 3. **Run the development server:**
    ```
-   npm run dev
-   ```
+ npm run dev
+  ```
 
 4. **Open your browser:**
-   Navigate to `http://localhost:3000` to view the application.
+   Navigate to `http://localhost:3000` to view the application. On first load you can choose an example scene to start from.
 
 5. **Build for production:**
    Use the following command to create an optimized build and start it:
@@ -68,19 +68,12 @@ To get started with the project, follow these steps:
    ```
 
 ## Features
-- Blank canvas UI with floating add button for spawning sounds.
-- New SoundInspector panel with animated entry.
-- ProceduralShapes instanced mesh visualizes audio levels.
-
-- A 3D scene rendered with React Three Fiber.
-- A floating sphere that demonstrates basic animation.
-- Basic note generation using Tone.js, showcasing sound synthesis capabilities.
-- Scroll or pinch to zoom the camera.
-- Loop objects trigger repeating beats with a progress ring.
-- Spatial audio positions each sound in 3D space.
-- Selecting an object reveals an effect panel for reverb, delay, and filters.
-- Dynamic bloom lighting responds to the music's bass frequencies and is
-  automatically disabled on low-power devices.
+- Spawn notes, chords, beats and loops from the sidebar or circular sound portals.
+- Example scenes can be loaded on first visit to quickly try out the app.
+- The SoundInspector provides a 16 step sequencer and per-object effects.
+- Instanced ProceduralShapes visualize audio levels in real time.
+- Scroll or pinch to zoom the camera, and drag objects to move them in 3D.
+- Spatial audio and bloom lighting react to your music.
 
 ## Future Enhancements
 

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,59 +1,42 @@
 "use client";
 import { Canvas } from "@react-three/fiber";
-import { motion } from "@motionone/react";
-import { AnimatePresence } from "framer-motion";
-import { useShapesStore } from "@/store/useShapesStore";
-import { EffectsPanel } from "../src/components/EffectsPanel";
+import { Physics } from "@react-three/rapier";
+import { PerspectiveCamera, AdaptiveDpr } from "@react-three/drei";
+import MusicalObject from "@/components/MusicalObject";
+import SpawnMenu from "@/components/SpawnMenu";
+import SoundPortals from "@/components/SoundPortals";
+import { EffectsPanel } from "@/components/EffectsPanel";
+import SoundInspector from "@/components/SoundInspector";
+import { useEffectSettings } from "@/store/useEffectSettings";
+import { useObjects } from "@/store/useObjects";
+import ExampleModal from "@/components/ExampleModal";
 
-const Home = () => {
-  const shapes = useShapesStore((s) => s.shapes);
-  const selectShape = useShapesStore((s) => s.selectShape);
-  const selectedShape = useShapesStore((s) => s.selectedShape);
+export default function Home() {
+  const selected = useEffectSettings((s) => s.selected);
+  const objects = useObjects((s) => s.objects);
+  const objType = objects.find((o) => o.id === selected)?.type;
 
   return (
     <>
       <Canvas className="fixed inset-0" shadows>
-        <ambientLight intensity={0.5} />
-        {shapes.map((shape) => (
-          <mesh
-            key={shape.id}
-            position={shape.position}
-            scale={[shape.scale, shape.scale, shape.scale]}
-            onClick={() => selectShape(shape.id)}
-          >
-            <sphereGeometry args={[1, 32, 32]} />
-            <meshStandardMaterial color="hotpink" />
-          </mesh>
-        ))}
+        <AdaptiveDpr pixelated />
+        <Physics>
+          <PerspectiveCamera makeDefault fov={50} position={[0, 5, 10]} />
+          <ambientLight intensity={0.4} />
+          <directionalLight position={[5, 10, 5]} intensity={0.8} castShadow />
+          <pointLight position={[0, 5, -5]} intensity={0.5} />
+          <MusicalObject />
+          <SoundPortals />
+        </Physics>
       </Canvas>
-      <button
-        className="add-sound fixed bottom-4 right-4 bg-white/80 text-black rounded-full w-12 h-12 md:w-14 md:h-14 flex items-center justify-center text-2xl"
-        onClick={() =>
-          useShapesStore.getState().addShape({
-            id: Date.now().toString(),
-            type: "sphere",
-            position: [0, 0, 0],
-            scale: 1,
-          })
-        }
-      >
-        +
-      </button>
-      <AnimatePresence>
-        {selectedShape && (
-          <motion.div
-            key="effects"
-            initial={{ opacity: 0, y: 20 }}
-            animate={{ opacity: 1, y: 0 }}
-            exit={{ opacity: 0, y: 20 }}
-            className="fixed bottom-24 left-1/2 -translate-x-1/2"
-          >
-            <EffectsPanel />
-          </motion.div>
-        )}
-      </AnimatePresence>
+      <SpawnMenu />
+      <ExampleModal />
+      {selected && objType && (
+        <SoundInspector objectId={selected} type={objType} />
+      )}
+      <div className="fixed bottom-4 right-4">
+        <EffectsPanel />
+      </div>
     </>
   );
-};
-
-export default Home;
+}

--- a/src/components/ExampleModal.tsx
+++ b/src/components/ExampleModal.tsx
@@ -1,0 +1,39 @@
+"use client";
+import React, { useState } from 'react';
+import { motion, AnimatePresence } from "framer-motion";
+import scenes from "@/config/exampleScenes.json";
+import { useObjects } from "@/store/useObjects";
+
+const ExampleModal: React.FC = () => {
+  const [open, setOpen] = useState(true);
+  const spawn = useObjects((s) => s.spawn);
+
+  const load = (scene: (typeof scenes)[0]) => {
+    scene.objects.forEach(obj => spawn(obj.type as any, obj.position as any));
+    setOpen(false);
+  };
+
+  return (
+    <AnimatePresence>
+      {open && (
+        <motion.div
+          className="fixed inset-0 bg-black/70 flex items-center justify-center z-10"
+          initial={{ opacity: 0 }}
+          animate={{ opacity: 1 }}
+          exit={{ opacity: 0 }}
+        >
+          <motion.div className="bg-white p-4 rounded" initial={{ scale: 0.8 }} animate={{ scale: 1 }}>
+            <h2 className="mb-2 font-bold">Load Example Scene</h2>
+            {scenes.map(scene => (
+              <button key={scene.name} className="block w-full text-left mb-1 p-1 bg-gray-200" onClick={() => load(scene)}>
+                {scene.name}
+              </button>
+            ))}
+          </motion.div>
+        </motion.div>
+      )}
+    </AnimatePresence>
+  );
+};
+
+export default ExampleModal;

--- a/src/components/SoundInspector.tsx
+++ b/src/components/SoundInspector.tsx
@@ -6,10 +6,17 @@ import * as Tone from "tone";
 import { useEffectSettings, defaultEffectParams } from "@/store/useEffectSettings";
 import { ObjectType } from "@/store/useObjects";
 import { useAudioSettings } from "@/store/useAudioSettings";
+import { playNote, playChord, playBeat } from "@/lib/audio";
 
 interface Props { objectId: string; type: ObjectType; }
 
 const stepsArray = new Array(16).fill(false);
+
+function chordNotes(root: string, type: string) {
+  const base = Tone.Frequency(root);
+  const intervals = type === "minor" ? [0, 3, 7] : type === "dim" ? [0, 3, 6] : [0, 4, 7];
+  return intervals.map((i) => base.transpose(i).toNote());
+}
 
 const SoundInspector: React.FC<Props> = ({ objectId, type }) => {
   const params = useEffectSettings((s) => s.effects[objectId] || defaultEffectParams);
@@ -17,78 +24,82 @@ const SoundInspector: React.FC<Props> = ({ objectId, type }) => {
   const [steps, setSteps] = useState<boolean[]>(stepsArray);
   const seqRef = useRef<Tone.Sequence | null>(null);
   const [pitch, setPitch] = useState("C4");
+  const [chordType, setChordType] = useState("major");
   const bpm = useAudioSettings((s) => s.bpm);
+
+  useEffect(() => {
+    Tone.Transport.bpm.value = bpm;
+  }, [bpm]);
 
   useEffect(() => {
     seqRef.current?.dispose();
     const callback = (_time: number, step: boolean) => {
       if (!step) return;
-      if (type === "note") Tone.Transport.scheduleOnce(() => Tone.start(), "+0");
+      if (type === "note") playNote(objectId, pitch);
+      else if (type === "chord") playChord(objectId, chordNotes(pitch, chordType));
+      else if (type === "beat") playBeat(objectId);
     };
     const seq = new Tone.Sequence(callback, steps, "16n");
     seq.start(0);
-    Tone.Transport.bpm.value = bpm;
     if (Tone.Transport.state !== "started") Tone.Transport.start();
     seqRef.current = seq;
     return () => {
       seq.dispose();
     };
-  }, [steps, pitch, bpm, type]);
+  }, [steps, pitch, chordType, type, objectId]);
 
   const toggleStep = (i: number) => {
-    const newSteps = [...steps];
-    newSteps[i] = !newSteps[i];
-    setSteps(newSteps);
+    const arr = [...steps];
+    arr[i] = !arr[i];
+    setSteps(arr);
   };
 
   return (
     <motion.div
-        key="panel"
-        className="fixed top-2 right-2 bg-black/60 text-white p-4 rounded-lg flex flex-col gap-2 w-56 md:w-72"
-        initial={{ opacity: 0, x: 50 }}
-        animate={{ opacity: 1, x: 0 }}
-        exit={{ opacity: 0, x: 50 }}
-      >
-        <select className="mb-2 text-black p-1 rounded">
-          <option>sine</option>
-          <option>square</option>
-          <option>triangle</option>
-        </select>
-        <div className="flex gap-2">
-          <Knob label="Reverb" min={0} max={1} step={0.01} value={params.reverb} onChange={(e)=>setEffect(objectId,{reverb:parseFloat(e.target.value)})} />
-          <Knob label="Delay" min={0} max={1} step={0.01} value={params.delay} onChange={(e)=>setEffect(objectId,{delay:parseFloat(e.target.value)})} />
-          <Knob label="Bits" min={0} max={1} step={0.01} value={0} onChange={()=>{}} />
+      key="panel"
+      className="fixed top-2 right-2 bg-black/60 text-white p-4 rounded-lg flex flex-col gap-2 w-56 md:w-72"
+      initial={{ opacity: 0, x: 50 }}
+      animate={{ opacity: 1, x: 0 }}
+      exit={{ opacity: 0, x: 50 }}
+    >
+      <div className="flex gap-2">
+        <Knob label="Reverb" min={0} max={1} step={0.01} value={params.reverb} onChange={(e)=>setEffect(objectId,{reverb:parseFloat(e.target.value)})} />
+        <Knob label="Delay" min={0} max={1} step={0.01} value={params.delay} onChange={(e)=>setEffect(objectId,{delay:parseFloat(e.target.value)})} />
+        <Knob label="Lowpass" min={100} max={20000} step={100} value={params.lowpass} onChange={(e)=>setEffect(objectId,{lowpass:parseFloat(e.target.value)})} />
+      </div>
+      {type === "note" && (
+        <div className="grid grid-cols-8 gap-1 mt-2">
+          {steps.map((s,i)=> (
+            <input key={i} type="checkbox" checked={s} onChange={()=>toggleStep(i)} />
+          ))}
+          <select value={pitch} onChange={(e)=>setPitch(e.target.value)} className="col-span-8 text-black p-1 rounded mt-1">
+            {['C4','D4','E4','F4','G4','A4','B4'].map(p=>(<option key={p}>{p}</option>))}
+          </select>
         </div>
-        {type === "note" && (
-          <div className="grid grid-cols-8 gap-1 mt-2">
-            {steps.map((s, i) => (
-              <input key={i} type="checkbox" checked={s} onChange={() => toggleStep(i)} />
-            ))}
-            <select value={pitch} onChange={(e)=>setPitch(e.target.value)} className="col-span-8 text-black p-1 rounded mt-1">
-              {['C4','D4','E4','F4','G4','A4','B4'].map(p=>(<option key={p}>{p}</option>))}
-            </select>
-          </div>
-        )}
-        {type === "chord" && (
-          <div className="grid grid-cols-8 gap-1 mt-2">
-            {steps.map((s,i)=>(
-              <input key={i} type="checkbox" checked={s} onChange={()=>toggleStep(i)} />
-            ))}
-            <select className="col-span-8 text-black p-1 rounded mt-1">
-              <option>major</option>
-              <option>minor</option>
-              <option>dim</option>
-            </select>
-          </div>
-        )}
-        {type === "beat" && (
-          <div className="grid grid-cols-8 gap-1 mt-2">
-            {steps.map((s,i)=>(
-              <input key={i} type="range" min={0} max={1} step={0.01} value={s ? 1 : 0} onChange={()=>toggleStep(i)} />
-            ))}
-          </div>
-        )}
-      </motion.div>
+      )}
+      {type === "chord" && (
+        <div className="grid grid-cols-8 gap-1 mt-2">
+          {steps.map((s,i)=> (
+            <input key={i} type="checkbox" checked={s} onChange={()=>toggleStep(i)} />
+          ))}
+          <select value={pitch} onChange={(e)=>setPitch(e.target.value)} className="col-span-4 text-black p-1 rounded mt-1">
+            {['C4','D4','E4','F4','G4','A4','B4'].map(p=>(<option key={p}>{p}</option>))}
+          </select>
+          <select value={chordType} onChange={(e)=>setChordType(e.target.value)} className="col-span-4 text-black p-1 rounded mt-1">
+            <option value="major">major</option>
+            <option value="minor">minor</option>
+            <option value="dim">dim</option>
+          </select>
+        </div>
+      )}
+      {type === "beat" && (
+        <div className="grid grid-cols-8 gap-1 mt-2">
+          {steps.map((s,i)=> (
+            <input key={i} type="checkbox" checked={s} onChange={()=>toggleStep(i)} />
+          ))}
+        </div>
+      )}
+    </motion.div>
   );
 };
 

--- a/src/config/exampleScenes.json
+++ b/src/config/exampleScenes.json
@@ -1,0 +1,23 @@
+[
+  {
+    "name": "Ambient Pad",
+    "objects": [
+      { "type": "chord", "position": [0,1,0] }
+    ]
+  },
+  {
+    "name": "Techno Loop",
+    "objects": [
+      { "type": "beat", "position": [0,1,0] },
+      { "type": "note", "position": [2,1,0] }
+    ]
+  },
+  {
+    "name": "Jazz Combo",
+    "objects": [
+      { "type": "note", "position": [-1,1,0] },
+      { "type": "chord", "position": [1,1,0] },
+      { "type": "beat", "position": [0,1,0] }
+    ]
+  }
+]

--- a/src/lib/engine.ts
+++ b/src/lib/engine.ts
@@ -1,0 +1,1 @@
+export * from './audio'


### PR DESCRIPTION
## Summary
- refactor `app/page.tsx` to use new stores and components
- implement step sequencer and per-object effects in `SoundInspector`
- add example scenes modal
- expose audio engine module
- update README with new features

## Testing
- `npx tsc --noEmit`
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_685b2fe008cc832680553386c1714197