### PR TITLE
Refactor canvas UI and bottom drawer

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -4,18 +4,14 @@ import { Physics } from "@react-three/rapier";
 import { PerspectiveCamera, AdaptiveDpr } from "@react-three/drei";
 import MusicalObject from "@/components/MusicalObject";
 import BottomDrawer from "@/components/BottomDrawer";
-import SoundInspector from "@/components/SoundInspector";
-import { useEffectSettings } from "@/store/useEffectSettings";
-import { useObjects } from "@/store/useObjects";
+import { useSelectedShape } from "@/store/useSelectedShape";
 import ExampleModal from "@/components/ExampleModal";
 import { useEffect } from "react";
 import * as Tone from "tone";
 import { playNote } from "@/lib/audio";
 
 export default function Home() {
-  const selected = useEffectSettings((s) => s.selected);
-  const objects = useObjects((s) => s.objects);
-  const objType = objects.find((o) => o.id === selected)?.type;
+  const selected = useSelectedShape((s) => s.selected);
 
   useEffect(() => {
     const start = async () => {
@@ -30,20 +26,19 @@ export default function Home() {
 
   return (
     <>
-      <Canvas className="fixed inset-0 w-screen h-screen" shadows>
-        <AdaptiveDpr pixelated />
-        <Physics>
-          <PerspectiveCamera makeDefault fov={50} position={[0, 5, 10]} />
-          <ambientLight intensity={0.4} />
-          <directionalLight position={[5, 10, 5]} intensity={0.8} castShadow />
-          <pointLight position={[0, 5, -5]} intensity={0.5} />
-          <MusicalObject />
-        </Physics>
-      </Canvas>
+      <div className="w-screen h-screen">
+        <Canvas className="w-full h-full" shadows>
+          <AdaptiveDpr pixelated />
+          <Physics>
+            <PerspectiveCamera makeDefault fov={50} position={[0, 5, 10]} />
+            <ambientLight intensity={0.4} />
+            <directionalLight position={[5, 10, 5]} intensity={0.8} castShadow />
+            <pointLight position={[0, 5, -5]} intensity={0.5} />
+            <MusicalObject />
+          </Physics>
+        </Canvas>
+      </div>
       <ExampleModal />
-      {selected && objType && (
-        <SoundInspector objectId={selected} type={objType} />
-      )}
       <BottomDrawer />
     </>
   );

--- a/src/components/BottomDrawer.tsx
+++ b/src/components/BottomDrawer.tsx
@@ -2,26 +2,39 @@
 import { useState, useMemo } from 'react'
 import { motion } from 'framer-motion'
 import { useObjects } from '@/store/useObjects'
-import { useEffectSettings } from '@/store/useEffectSettings'
 import { useAudioSettings } from '@/store/useAudioSettings'
+import { useEffectSettings } from '@/store/useEffectSettings'
+import { useSelectedShape } from '@/store/useSelectedShape'
 import { triggerSound } from '@/lib/soundTriggers'
 import Knob from './JSAudioKnobs'
+import { objectTypes, ObjectType } from '@/config/objectTypes'
 
 export default function BottomDrawer() {
   const spawn = useObjects(s => s.spawn)
   const objects = useObjects(s => s.objects)
-  const selected = useEffectSettings(s => s.selected)
-  const select = useEffectSettings(s => s.select)
+  const { selected, selectShape } = useSelectedShape(s => ({
+    selected: s.selected,
+    selectShape: s.selectShape,
+  }))
+  const obj = useMemo(() => objects.find(o => o.id === selected), [objects, selected])
+  const [mode, setMode] = useState<ObjectType>('note')
+
   const {
     volume, setVolume,
     chorusDepth, setChorusDepth,
     delayFeedback, setDelayFeedback,
     reverbWet, setReverbWet,
+    bitcrusherBits, setBitcrusherBits,
     filterFrequency, setFilterFrequency,
   } = useAudioSettings()
 
-  const obj = useMemo(() => objects.find(o => o.id === selected), [objects, selected])
-  const [mode, setMode] = useState<'note'|'chord'|'beat'|'loop'>('note')
+  const { setEffect, getParams } = useEffectSettings()
+  const params = selected ? getParams(selected) : null
+
+  const handleSpawn = () => {
+    const id = spawn('note')
+    selectShape(id)
+  }
 
   const handlePlay = () => {
     if (!selected) return
@@ -29,29 +42,17 @@ export default function BottomDrawer() {
   }
 
   return (
-    <motion.div
-      initial={{ y: '100%' }}
-      animate={{ y: selected ? 0 : 'calc(100% - 4rem)' }}
-      transition={{ type: 'spring', stiffness: 300, damping: 30 }}
-      className="fixed bottom-0 left-0 w-full pointer-events-auto z-20"
-    >
-      <div className="bg-black/70 text-white p-4 flex flex-col gap-2">
-        {!selected && (
-          <button
-            onClick={() => spawn('note')}
-            className="w-12 h-12 rounded-full bg-blue-600 flex items-center justify-center text-2xl shadow-lg"
-          >
-            +
-          </button>
-        )}
+    <div className="pointer-events-none">
+      <motion.div
+        initial={{ y: '100%' }}
+        animate={{ y: selected ? 0 : '100%' }}
+        transition={{ type: 'spring', stiffness: 300, damping: 30 }}
+        className="fixed bottom-0 left-0 w-full pointer-events-auto z-10"
+      >
         {selected && obj && (
-          <>
-            <div className="flex items-center gap-2">
-              <button onClick={handlePlay} className="px-3 py-1 bg-green-500 rounded">Play</button>
-              <button onClick={() => select(null)} className="ml-auto px-3 py-1 bg-gray-600 rounded">Close</button>
-            </div>
+          <div className="bg-black/70 text-white p-4 flex flex-col gap-2">
             <div className="flex gap-2">
-              {(['note','chord','beat','loop'] as const).map(t => (
+              {objectTypes.map(t => (
                 <button
                   key={t}
                   onClick={() => setMode(t)}
@@ -65,10 +66,29 @@ export default function BottomDrawer() {
               <Knob label="Delay" min={0} max={1} step={0.01} value={delayFeedback} onChange={e=>setDelayFeedback(parseFloat(e.target.value))} />
               <Knob label="Reverb" min={0} max={1} step={0.01} value={reverbWet} onChange={e=>setReverbWet(parseFloat(e.target.value))} />
               <Knob label="Filter" min={20} max={1000} step={10} value={filterFrequency} onChange={e=>setFilterFrequency(parseFloat(e.target.value))} />
+              <Knob label="Bits" min={1} max={16} step={1} value={bitcrusherBits} onChange={e=>setBitcrusherBits(parseInt(e.target.value,10))} />
             </div>
-          </>
+            {params && (
+              <div className="flex gap-4 overflow-x-auto pb-2">
+                <Knob label="Reverb" min={0} max={1} step={0.01} value={params.reverb} onChange={e=>setEffect(selected!, { reverb: parseFloat(e.target.value) })} />
+                <Knob label="Delay" min={0} max={1} step={0.01} value={params.delay} onChange={e=>setEffect(selected!, { delay: parseFloat(e.target.value) })} />
+                <Knob label="Lowpass" min={100} max={20000} step={100} value={params.lowpass} onChange={e=>setEffect(selected!, { lowpass: parseFloat(e.target.value) })} />
+                <Knob label="Highpass" min={0} max={1000} step={10} value={params.highpass} onChange={e=>setEffect(selected!, { highpass: parseFloat(e.target.value) })} />
+              </div>
+            )}
+            <div className="flex gap-2">
+              <button onClick={handlePlay} className="px-3 py-1 bg-green-500 rounded">Play</button>
+              <button onClick={() => selectShape(null)} className="ml-auto px-3 py-1 bg-gray-600 rounded">Close</button>
+            </div>
+          </div>
         )}
-      </div>
-    </motion.div>
+      </motion.div>
+      <button
+        onClick={handleSpawn}
+        className="fixed bottom-4 left-4 w-12 h-12 rounded-full bg-primary shadow-lg flex items-center justify-center text-2xl text-white pointer-events-auto"
+      >
+        +
+      </button>
+    </div>
   )
 }

--- a/src/components/MusicalObject.tsx
+++ b/src/components/MusicalObject.tsx
@@ -2,12 +2,10 @@
 // src/components/MusicalObject.tsx
 import React, { useMemo } from 'react'
 import { Instances, Instance } from '@react-three/drei'
-import { AnimatePresence } from 'framer-motion'
 import { objectConfigs, objectTypes, ObjectType } from '../config/objectTypes'
 import { useObjects, MusicalObject as Obj } from '../store/useObjects'
 import ShapeFactory from './ShapeFactory'
-import EffectPanel from "./EffectPanel"
-import { useEffectSettings } from '../store/useEffectSettings'
+import { useSelectedShape } from '../store/useSelectedShape'
 import { usePhysicsStore } from '../lib/physics'
 import * as Tone from 'tone'
 import * as THREE from 'three'
@@ -31,8 +29,8 @@ const MusicalObjectInstances: React.FC = () => {
   const objects = useObjects((s) => s.objects)
   const grouped = useMemo(() => groupByType(objects), [objects])
   const transforms = usePhysicsStore((s) => s.transforms)
-  const select = useEffectSettings((s) => s.select)
-  const selected = useEffectSettings((s) => s.selected)
+  const select = useSelectedShape((s) => s.selectShape)
+  const selected = useSelectedShape((s) => s.selected)
 
   return (
     <>
@@ -70,14 +68,7 @@ const MusicalObjectInstances: React.FC = () => {
           </Instances>
         )
       })}
-      <AnimatePresence>
-        {selected && transforms[selected] && (
-          <EffectPanel
-            objectId={selected}
-            position={transforms[selected].position as [number, number, number]}
-          />
-        )}
-      </AnimatePresence>
+      {/* EffectPanel removed - Drawer handles UI */}
     </>
   )
 }

--- a/src/components/ProceduralShapes.tsx
+++ b/src/components/ProceduralShapes.tsx
@@ -4,7 +4,7 @@ import { useFrame, useThree } from "@react-three/fiber";
 import * as THREE from "three";
 import { getAnalyser } from "@/lib/analyser";
 import { useObjects } from "@/store/useObjects";
-import { useEffectSettings } from "@/store/useEffectSettings";
+import { useSelectedShape } from "@/store/useSelectedShape";
 import { useAudioSettings } from "@/store/useAudioSettings";
 
 type EffectSnapshot = {
@@ -19,7 +19,7 @@ const tempObject = new THREE.Object3D();
 
 const ProceduralShapes: React.FC = () => {
   const objects = useObjects((s) => s.objects);
-  const select = useEffectSettings((s) => s.select);
+  const select = useSelectedShape((s) => s.selectShape);
   const instRef = useRef<THREE.InstancedMesh>(null!);
   const dataRef = useRef<Uint8Array | null>(null);
   const analyserRef = useRef<AnalyserNode | null>(null);

--- a/src/components/SingleMusicalObject.tsx
+++ b/src/components/SingleMusicalObject.tsx
@@ -12,9 +12,7 @@ import { triggerSound } from '../lib/soundTriggers'
 import { ObjectType } from '../store/useObjects'
 import { objectConfigs } from '../config/objectTypes'
 import ProceduralShape from './ProceduralShape'
-import { AnimatePresence } from 'framer-motion'
-import { useEffectSettings } from '../store/useEffectSettings'
-import EffectPanel from './EffectPanel'
+import { useSelectedShape } from '../store/useSelectedShape'
 
 // Props interface for MusicalObject component
 interface MusicalObjectProps {
@@ -32,8 +30,8 @@ export const SingleMusicalObject: React.FC<MusicalObjectProps> = ({ id, type, po
   // dragging state
   const [dragging, setDragging] = useState(false)
   const [moved, setMoved] = useState(false)
-  const select = useEffectSettings((s) => s.select)
-  const selected = useEffectSettings((s) => s.selected)
+  const select = useSelectedShape((s) => s.selectShape)
+  const selected = useSelectedShape((s) => s.selected)
   const { raycaster, mouse, camera } = useThree()
   const plane = useMemo(() => new THREE.Plane(new THREE.Vector3(0, 1, 0), 0), [])
   const intersectPoint = useMemo(() => new THREE.Vector3(), [])
@@ -118,11 +116,6 @@ export const SingleMusicalObject: React.FC<MusicalObjectProps> = ({ id, type, po
         onPointerMissed={() => setDragging(false)}
       >
         <ProceduralShape type={type} />
-        <AnimatePresence>
-          {selected === id && (
-            <EffectPanel objectId={id} position={[0, 1, 0]} />
-          )}
-        </AnimatePresence>
       </a.group>
     </RigidBody>
   )

--- a/src/store/useSelectedShape.ts
+++ b/src/store/useSelectedShape.ts
@@ -1,0 +1,11 @@
+import { create } from 'zustand'
+
+interface SelectedShapeState {
+  selected: string | null
+  selectShape: (id: string | null) => void
+}
+
+export const useSelectedShape = create<SelectedShapeState>((set) => ({
+  selected: null,
+  selectShape: (id: string | null) => set({ selected: id }),
+}))

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,7 +1,11 @@
 module.exports = {
   content: ['./app/**/*.{js,ts,jsx,tsx}', './src/**/*.{js,ts,jsx,tsx}'],
   theme: {
-    extend: {},
+    extend: {
+      colors: {
+        primary: '#2563eb',
+      },
+    },
   },
   plugins: [],
 }


### PR DESCRIPTION
## Summary
- create `useSelectedShape` store for current selection
- refactor `BottomDrawer` with spawn button and controls
- switch components to use new selection store
- remove 3D effect panel
- expand Tailwind colors and make Canvas fill viewport

## Testing
- `npm run lint`
- `npx tsc --noEmit`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_685b4248778c83268a89811f4eb11fc2