### PR TITLE
Add fullscreen canvas with gradient background and FAB drawer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,15 @@
+## [Unreleased] – 2025-06-24
+
+### Added
+- Full-screen `<Canvas>` wrapper with animated gradient backdrop  
+- Corner FAB component for spawning shapes  
+- `BottomDrawer` component with Motion One slide animations  
+- `useSelectedShape` and `useEffectSettings` Zustand stores
+
+### Changed
+- Removed legacy `SpawnMenu`, `SoundPortals`, and fixed `EffectsPanel`  
+- Refactored `app/page.tsx` for drawer integration and responsive styling
+
+### Fixed
+- AudioContext now starts on first user gesture  
+

--- a/README.md
+++ b/README.md
@@ -48,10 +48,12 @@ To get started with the project, follow these steps:
 2. **Install dependencies:**
    Run the following command from the project root to install all required packages:
    ```bash
-   npm install
-   ```
-   The repository includes an `.npmrc` file that enables `legacy-peer-deps` to
-   avoid peer dependency conflicts during installation.
+ npm install
+  ```
+  The repository includes an `.npmrc` file that enables `legacy-peer-deps` to
+  avoid peer dependency conflicts during installation. If new dependencies are
+  added (e.g. `@motionone/react` and `@react-three/drei`), run the install
+  command again.
 
 3. **Run the development server:**
    ```
@@ -68,12 +70,22 @@ To get started with the project, follow these steps:
    ```
 
 ## Features
+- Full-screen immersive canvas with animated gradient background (Blobmixer style).
+- Corner FAB for spawning shapes.
+- Contextual bottom drawer with Motion One animations.
 - Spawn notes, chords, beats and loops from the sidebar or circular sound portals.
 - Example scenes can be loaded on first visit to quickly try out the app.
 - The SoundInspector provides a 16 step sequencer and per-object effects.
 - Instanced ProceduralShapes visualize audio levels in real time.
 - Scroll or pinch to zoom the camera, and drag objects to move them in 3D.
 - Spatial audio and bloom lighting react to your music.
+
+## UI & Controls
+
+- Tap the **+** button in the bottom-left corner to spawn a shape.
+- Selecting a shape opens the bottom drawer with playback and effect knobs.
+- Use the Note/Chord/Beat/Loop tabs to trigger different sounds.
+- Close the drawer with the "Close" button or by deselecting the shape.
 
 ## Future Enhancements
 

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -2,6 +2,7 @@
 import { Canvas } from "@react-three/fiber";
 import { Physics } from "@react-three/rapier";
 import { PerspectiveCamera, AdaptiveDpr } from "@react-three/drei";
+import AnimatedGradient from "@/components/AnimatedGradient";
 import MusicalObject from "@/components/MusicalObject";
 import BottomDrawer from "@/components/BottomDrawer";
 import { useSelectedShape } from "@/store/useSelectedShape";
@@ -26,9 +27,10 @@ export default function Home() {
 
   return (
     <>
-      <div className="w-screen h-screen">
+      <div className="h-screen w-screen relative">
         <Canvas className="w-full h-full" shadows>
           <AdaptiveDpr pixelated />
+          <AnimatedGradient />
           <Physics>
             <PerspectiveCamera makeDefault fov={50} position={[0, 5, 10]} />
             <ambientLight intensity={0.4} />

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "1.0.0",
       "dependencies": {
         "@dimforge/rapier3d-compat": "^0.17.3",
+        "@heroicons/react": "^2.2.0",
         "@motionone/react": "^10.16.4",
         "@react-spring/three": "^10.0.1",
         "@react-three/drei": "^10.3.0",
@@ -409,6 +410,15 @@
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/@heroicons/react": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@heroicons/react/-/react-2.2.0.tgz",
+      "integrity": "sha512-LMcepvRaS9LYHJGsF0zzmgKCUim/X3N/DQKc4jepAXJ7l8QxJ1PmxJzqplF2Z3FE4PqBAIGyJAQ/w4B5dsqbtQ==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": ">= 16 || ^19.0.0-rc"
       }
     },
     "node_modules/@humanfs/core": {

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
   },
   "dependencies": {
     "@dimforge/rapier3d-compat": "^0.17.3",
+    "@heroicons/react": "^2.2.0",
     "@motionone/react": "^10.16.4",
     "@react-spring/three": "^10.0.1",
     "@react-three/drei": "^10.3.0",

--- a/src/components/AnimatedGradient.tsx
+++ b/src/components/AnimatedGradient.tsx
@@ -1,0 +1,23 @@
+'use client'
+import { useMemo } from 'react'
+import { useFrame } from '@react-three/fiber'
+import { GradientTexture } from '@react-three/drei'
+import * as THREE from 'three'
+
+export default function AnimatedGradient() {
+  const colors = useMemo(() => [new THREE.Color('#ff0080'), new THREE.Color('#00ccff')], [])
+  useFrame(({ clock }) => {
+    const t = clock.getElapsedTime() * 0.05
+    colors[0].setHSL((t % 1), 0.5, 0.5)
+    colors[1].setHSL(((t + 0.5) % 1), 0.5, 0.5)
+  })
+  return (
+    <mesh position={[0, 0, -10]} scale={[50, 50, 1]}>
+      <planeGeometry args={[1, 1]} />
+      <meshBasicMaterial>
+        {/* GradientTexture uses the mutable THREE.Color objects */}
+        <GradientTexture stops={[0, 1]} colors={colors as any} />
+      </meshBasicMaterial>
+    </mesh>
+  )
+}

--- a/src/components/BottomDrawer.tsx
+++ b/src/components/BottomDrawer.tsx
@@ -1,12 +1,13 @@
 'use client'
 import { useState, useMemo } from 'react'
-import { motion } from 'framer-motion'
+import { motion } from '@motionone/react'
 import { useObjects } from '@/store/useObjects'
 import { useAudioSettings } from '@/store/useAudioSettings'
 import { useEffectSettings } from '@/store/useEffectSettings'
 import { useSelectedShape } from '@/store/useSelectedShape'
 import { triggerSound } from '@/lib/soundTriggers'
 import Knob from './JSAudioKnobs'
+import { PlusIcon } from '@heroicons/react/24/solid'
 import { objectTypes, ObjectType } from '@/config/objectTypes'
 
 export default function BottomDrawer() {
@@ -18,6 +19,7 @@ export default function BottomDrawer() {
   }))
   const obj = useMemo(() => objects.find(o => o.id === selected), [objects, selected])
   const [mode, setMode] = useState<ObjectType>('note')
+  const [playing, setPlaying] = useState(false)
 
   const {
     volume, setVolume,
@@ -31,63 +33,82 @@ export default function BottomDrawer() {
   const { setEffect, getParams } = useEffectSettings()
   const params = selected ? getParams(selected) : null
 
-  const handleSpawn = () => {
+  const spawnShape = () => {
     const id = spawn('note')
     selectShape(id)
+    triggerSound('note', id)
   }
 
-  const handlePlay = () => {
+  const togglePlay = () => {
     if (!selected) return
-    triggerSound(mode, selected)
+    const target = objects.find(o => o.id === selected)
+    if (!target) return
+    if (playing && target.type === 'loop') {
+      // stopLoop is defined in audio.ts
+      // dynamic import to avoid circular
+      const { stopLoop } = require('@/lib/audio')
+      stopLoop(selected)
+      setPlaying(false)
+    } else {
+      triggerSound(mode, selected)
+      setPlaying(true)
+    }
   }
 
+  const drawerClosedY = 120
   return (
     <div className="pointer-events-none">
       <motion.div
-        initial={{ y: '100%' }}
-        animate={{ y: selected ? 0 : '100%' }}
+        initial={{ y: drawerClosedY }}
+        animate={{ y: selected ? 0 : drawerClosedY }}
         transition={{ type: 'spring', stiffness: 300, damping: 30 }}
-        className="fixed bottom-0 left-0 w-full pointer-events-auto z-10"
+        className="fixed bottom-0 left-0 w-full bg-gray-900 bg-opacity-80 p-4 pointer-events-auto"
       >
         {selected && obj && (
-          <div className="bg-black/70 text-white p-4 flex flex-col gap-2">
+          <div className="flex flex-col gap-2 text-white">
             <div className="flex gap-2">
-              {objectTypes.map(t => (
+              {objectTypes.map((t) => (
                 <button
                   key={t}
                   onClick={() => setMode(t)}
-                  className={`px-2 py-1 rounded ${mode===t ? 'bg-blue-500' : 'bg-gray-700'}`}
-                >{t}</button>
+                  className={`px-2 py-1 rounded ${mode === t ? 'bg-blue-500' : 'bg-gray-700'}`}
+                >
+                  {t}
+                </button>
               ))}
             </div>
             <div className="flex gap-4 overflow-x-auto py-2">
-              <Knob label="Vol" min={0} max={1} step={0.01} value={volume} onChange={e=>setVolume(parseFloat(e.target.value))} />
-              <Knob label="Chorus" min={0} max={1} step={0.01} value={chorusDepth} onChange={e=>setChorusDepth(parseFloat(e.target.value))} />
-              <Knob label="Delay" min={0} max={1} step={0.01} value={delayFeedback} onChange={e=>setDelayFeedback(parseFloat(e.target.value))} />
-              <Knob label="Reverb" min={0} max={1} step={0.01} value={reverbWet} onChange={e=>setReverbWet(parseFloat(e.target.value))} />
-              <Knob label="Filter" min={20} max={1000} step={10} value={filterFrequency} onChange={e=>setFilterFrequency(parseFloat(e.target.value))} />
-              <Knob label="Bits" min={1} max={16} step={1} value={bitcrusherBits} onChange={e=>setBitcrusherBits(parseInt(e.target.value,10))} />
+              <Knob label="Vol" min={0} max={1} step={0.01} value={volume} onChange={(e) => setVolume(parseFloat(e.target.value))} />
+              <Knob label="Chorus" min={0} max={1} step={0.01} value={chorusDepth} onChange={(e) => setChorusDepth(parseFloat(e.target.value))} />
+              <Knob label="Delay" min={0} max={1} step={0.01} value={delayFeedback} onChange={(e) => setDelayFeedback(parseFloat(e.target.value))} />
+              <Knob label="Reverb" min={0} max={1} step={0.01} value={reverbWet} onChange={(e) => setReverbWet(parseFloat(e.target.value))} />
+              <Knob label="Filter" min={20} max={1000} step={10} value={filterFrequency} onChange={(e) => setFilterFrequency(parseFloat(e.target.value))} />
+              <Knob label="Bits" min={1} max={16} step={1} value={bitcrusherBits} onChange={(e) => setBitcrusherBits(parseInt(e.target.value, 10))} />
             </div>
             {params && (
               <div className="flex gap-4 overflow-x-auto pb-2">
-                <Knob label="Reverb" min={0} max={1} step={0.01} value={params.reverb} onChange={e=>setEffect(selected!, { reverb: parseFloat(e.target.value) })} />
-                <Knob label="Delay" min={0} max={1} step={0.01} value={params.delay} onChange={e=>setEffect(selected!, { delay: parseFloat(e.target.value) })} />
-                <Knob label="Lowpass" min={100} max={20000} step={100} value={params.lowpass} onChange={e=>setEffect(selected!, { lowpass: parseFloat(e.target.value) })} />
-                <Knob label="Highpass" min={0} max={1000} step={10} value={params.highpass} onChange={e=>setEffect(selected!, { highpass: parseFloat(e.target.value) })} />
+                <Knob label="Reverb" min={0} max={1} step={0.01} value={params.reverb} onChange={(e) => setEffect(selected!, { reverb: parseFloat(e.target.value) })} />
+                <Knob label="Delay" min={0} max={1} step={0.01} value={params.delay} onChange={(e) => setEffect(selected!, { delay: parseFloat(e.target.value) })} />
+                <Knob label="Lowpass" min={100} max={20000} step={100} value={params.lowpass} onChange={(e) => setEffect(selected!, { lowpass: parseFloat(e.target.value) })} />
+                <Knob label="Highpass" min={0} max={1000} step={10} value={params.highpass} onChange={(e) => setEffect(selected!, { highpass: parseFloat(e.target.value) })} />
               </div>
             )}
             <div className="flex gap-2">
-              <button onClick={handlePlay} className="px-3 py-1 bg-green-500 rounded">Play</button>
-              <button onClick={() => selectShape(null)} className="ml-auto px-3 py-1 bg-gray-600 rounded">Close</button>
+              <button onClick={togglePlay} className="px-3 py-1 bg-green-500 rounded">
+                {playing ? 'Pause' : 'Play'}
+              </button>
+              <button onClick={() => selectShape(null)} className="ml-auto px-3 py-1 bg-gray-600 rounded">
+                Close
+              </button>
             </div>
           </div>
         )}
       </motion.div>
       <button
-        onClick={handleSpawn}
-        className="fixed bottom-4 left-4 w-12 h-12 rounded-full bg-primary shadow-lg flex items-center justify-center text-2xl text-white pointer-events-auto"
+        onClick={spawnShape}
+        className="fixed bottom-4 left-4 md:bottom-6 md:left-6 w-12 h-12 rounded-full bg-indigo-600 shadow-2xl hover:bg-indigo-500 flex items-center justify-center pointer-events-auto"
       >
-        +
+        <PlusIcon className="w-6 h-6 text-white" />
       </button>
     </div>
   )


### PR DESCRIPTION
## Summary
- add animated gradient backdrop component
- update bottom drawer with Motion One and FAB button
- wrap Canvas with fullscreen div and include gradient
- install Heroicons
- document new UI features and changelog

## Testing
- `npm run lint`
- `npx tsc --noEmit`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_685b476fcfec8326a78730b8624f6659