### PR TITLE
Fix infinite update loops

### DIFF
--- a/src/components/BottomDrawer.tsx
+++ b/src/components/BottomDrawer.tsx
@@ -1,5 +1,5 @@
 'use client'
-import { useState, useMemo } from 'react'
+import { useState, useMemo, useCallback } from 'react'
 import { motion } from '@motionone/react'
 import { useObjects } from '@/store/useObjects'
 import { useAudioSettings } from '@/store/useAudioSettings'
@@ -33,19 +33,17 @@ export default function BottomDrawer() {
   const { setEffect, getParams } = useEffectSettings()
   const params = selected ? getParams(selected) : null
 
-  const spawnShape = () => {
+  const spawnShape = useCallback(() => {
     const id = spawn('note')
     selectShape(id)
     triggerSound('note', id)
-  }
+  }, [spawn, selectShape])
 
-  const togglePlay = () => {
+  const togglePlay = useCallback(() => {
     if (!selected) return
-    const target = objects.find(o => o.id === selected)
+    const target = objects.find((o) => o.id === selected)
     if (!target) return
     if (playing && target.type === 'loop') {
-      // stopLoop is defined in audio.ts
-      // dynamic import to avoid circular
       const { stopLoop } = require('@/lib/audio')
       stopLoop(selected)
       setPlaying(false)
@@ -53,7 +51,7 @@ export default function BottomDrawer() {
       triggerSound(mode, selected)
       setPlaying(true)
     }
-  }
+  }, [selected, objects, playing, mode])
 
   const drawerClosedY = 120
   return (

--- a/src/components/PortalRing.tsx
+++ b/src/components/PortalRing.tsx
@@ -1,6 +1,6 @@
 'use client'
 // src/components/PortalRing.tsx
-import React, { useRef } from 'react'
+import React, { useRef, useCallback } from 'react'
 import { useFrame } from '@react-three/fiber'
 import { Float } from '@react-three/drei'
 import type { Mesh } from 'three'
@@ -64,15 +64,18 @@ const PortalRing: React.FC = () => {
   const { groupRef, getPosition } = usePortalRing(portalConfigs.length)
 
   // debounce click interval
-  let lastClick = 0
-  const handlePortalClick = async (note: string) => {
-    const now = performance.now()
-    if (now - lastClick < 50) return
-    lastClick = now
-    await Tone.start()
-    await Tone.getContext().resume()
-    await playNote(note)
-  }
+  const lastClick = useRef(0)
+  const handlePortalClick = useCallback(
+    async (note: string) => {
+      const now = performance.now()
+      if (now - lastClick.current < 50) return
+      lastClick.current = now
+      await Tone.start()
+      await Tone.getContext().resume()
+      await playNote(note)
+    },
+    []
+  )
 
   return (
     <group ref={groupRef}>

--- a/src/components/SpawnMenu.tsx
+++ b/src/components/SpawnMenu.tsx
@@ -1,5 +1,5 @@
 'use client'
-import React, { useEffect, useState } from 'react'
+import React, { useEffect, useState, useCallback } from 'react'
 import { motion } from '@motionone/react'
 import { useObjects } from '../store/useObjects'
 import { objectTypes, objectConfigs } from '../config/objectTypes'
@@ -21,6 +21,10 @@ const SpawnMenu = () => {
   const isMobile = useIsMobile()
   const [open, setOpen] = useState(!isMobile)
 
+  const handleSpawn = useCallback((t: string) => {
+    spawn(t as any)
+  }, [spawn])
+
   useEffect(() => {
     setOpen(!isMobile)
   }, [isMobile])
@@ -38,7 +42,7 @@ const SpawnMenu = () => {
           whileHover={{ scale: 1.1 }}
           key={t}
           className={styles.spawnButton}
-          onClick={() => spawn(t)}
+          onClick={() => handleSpawn(t)}
         >
           {objectConfigs[t].label}
         </motion.button>
@@ -57,7 +61,7 @@ const SpawnMenu = () => {
           whileHover={{ scale: 1.1 }}
           key={t}
           className={styles.spawnButton}
-          onClick={() => spawn(t)}
+          onClick={() => handleSpawn(t)}
         >
           {objectConfigs[t].label}
         </motion.button>


### PR DESCRIPTION
## Summary
- memoize event handlers in SceneCanvas to avoid effect re-registration
- memoize spawn and play callbacks in BottomDrawer
- memoize spawn callbacks in SpawnMenu
- debounce portal clicks with useCallback
- memoize pointer handlers for SingleMusicalObject

## Testing
- `npm run lint`
- `npx tsc --noEmit`
- `npm run build`
- `npm run start` *(manual curl check)*

------
https://chatgpt.com/codex/tasks/task_e_685b5492299c8326a297200bee3a614e