### PR TITLE
Fix Tone autostart and improve debugging

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "dev": "next dev --turbopack",
     "build": "next build",
-    "start": "next start",
+    "start": "NODE_ENV=development next start",
     "lint": "next lint",
     "test": "node tests/regression.js",
     "test:cypress": "cypress run"

--- a/src/components/BottomDrawer.tsx
+++ b/src/components/BottomDrawer.tsx
@@ -6,6 +6,7 @@ import { useAudioSettings } from '@/store/useAudioSettings'
 import { useEffectSettings } from '@/store/useEffectSettings'
 import { useSelectedShape } from '@/store/useSelectedShape'
 import { triggerSound } from '@/lib/soundTriggers'
+import * as Tone from 'tone'
 import Knob from './JSAudioKnobs'
 import { PlusIcon } from '@heroicons/react/24/solid'
 import { objectTypes, ObjectType } from '@/config/objectTypes'
@@ -33,13 +34,15 @@ export default function BottomDrawer() {
   const { setEffect, getParams } = useEffectSettings()
   const params = selected ? getParams(selected) : null
 
-  const spawnShape = useCallback(() => {
+  const spawnShape = useCallback(async () => {
+    await Tone.start()
+    await Tone.getContext().resume()
     const id = spawn('note')
     selectShape(id)
-    triggerSound('note', id)
+    await triggerSound('note', id)
   }, [spawn, selectShape])
 
-  const togglePlay = useCallback(() => {
+  const togglePlay = useCallback(async () => {
     if (!selected) return
     const target = objects.find((o) => o.id === selected)
     if (!target) return
@@ -48,7 +51,9 @@ export default function BottomDrawer() {
       stopLoop(selected)
       setPlaying(false)
     } else {
-      triggerSound(mode, selected)
+      await Tone.start()
+      await Tone.getContext().resume()
+      await triggerSound(mode, selected)
       setPlaying(true)
     }
   }, [selected, objects, playing, mode])

--- a/src/components/MusicalObject.tsx
+++ b/src/components/MusicalObject.tsx
@@ -60,7 +60,7 @@ const MusicalObjectInstances: React.FC = () => {
                     select(obj.id)
                     await Tone.start()
                     await Tone.getContext().resume()
-                    triggerSound(obj.type, obj.id)
+                    await triggerSound(obj.type, obj.id)
                   }}
                 />
               )

--- a/src/components/SingleMusicalObject.tsx
+++ b/src/components/SingleMusicalObject.tsx
@@ -39,11 +39,6 @@ export const SingleMusicalObject: React.FC<MusicalObjectProps> = ({ id, type, po
   const meterRef = useRef<Tone.Meter | null>(null)
   const pannerRef = useRef<PannerNode | null>(null)
 
-  useEffect(() => {
-    meterRef.current = getObjectMeter(id)
-    pannerRef.current = getObjectPanner(id)
-  }, [id])
-
   useFrame(() => {
     if (!dragging || !bodyRef.current) return
     raycaster.setFromCamera(mouse, camera)
@@ -102,7 +97,10 @@ export const SingleMusicalObject: React.FC<MusicalObjectProps> = ({ id, type, po
       if (!moved) select(id)
       await Tone.start()
       await Tone.getContext().resume()
-      triggerSound(type, id)
+      // First user interaction initializes audio and creates nodes
+      await triggerSound(type, id)
+      meterRef.current = getObjectMeter(id)
+      pannerRef.current = getObjectPanner(id)
     },
     [moved, select, id, type]
   )
@@ -116,7 +114,11 @@ export const SingleMusicalObject: React.FC<MusicalObjectProps> = ({ id, type, po
       linearDamping={0.9}
       mass={1}
       position={position}
-      onCollisionEnter={() => triggerSound(type, id)}
+      onCollisionEnter={async () => {
+        await triggerSound(type, id)
+        meterRef.current = getObjectMeter(id)
+        pannerRef.current = getObjectPanner(id)
+      }}
     >
       <a.group
         ref={meshRef as React.MutableRefObject<Object3D>}

--- a/src/lib/audio.ts
+++ b/src/lib/audio.ts
@@ -30,7 +30,13 @@ import {
 let noteSynth: Tone.Synth
 let chordSynth: Tone.PolySynth
 let beatSynth: Tone.MembraneSynth
+// Flag indicating if synthesis nodes have been created yet.
+// This stays false until a user gesture triggers Tone.start().
 let audioInitialized = false
+
+export function isAudioInitialized() {
+  return audioInitialized
+}
 let masterVolumeNode: Tone.Volume
 
 let chorus: Chorus
@@ -145,11 +151,14 @@ function getObjectSynth(id: string, type: ObjectType) {
   return os
 }
 
+// Meters and panners are created on demand after audio init.
 export function getObjectMeter(id: string): Tone.Meter | null {
+  if (!audioInitialized) return null
   return objectSynths.get(id)?.meter ?? null
 }
 
 export function getObjectPanner(id: string): PannerNode | null {
+  if (!audioInitialized) return null
   return objectSynths.get(id)?.panner ?? null
 }
 

--- a/src/lib/soundTriggers.ts
+++ b/src/lib/soundTriggers.ts
@@ -4,14 +4,14 @@ import { playNote, playChord, playBeat, startLoop } from './audio'
 /**
  * Trigger a sound based on object type.
  */
-export function triggerSound(type: ObjectType, id: string): void {
+export async function triggerSound(type: ObjectType, id: string): Promise<void> {
   if (type === 'note') {
-    playNote(id)
+    await playNote(id)
   } else if (type === 'chord') {
-    playChord(id)
+    await playChord(id)
   } else if (type === 'beat') {
-    playBeat(id)
+    await playBeat(id)
   } else {
-    startLoop(id)
+    await startLoop(id)
   }
 }


### PR DESCRIPTION
## Summary
- ensure audio nodes are created only after a user gesture
- defer Tone triggers in musical object handlers
- expose development errors by starting Next with `NODE_ENV=development`

## Testing
- `npx tsc --noEmit`
- `npm run lint`
- `npm run build`
- `npm test` *(fails: EADDRINUSE & playwright browsers missing)*

------
https://chatgpt.com/codex/tasks/task_e_685b640a51fc83269fb7a59acaccdb82