### PR TITLE
Fix audio initialization and analyser usage

### DIFF
--- a/src/components/AudioVisualizer.tsx
+++ b/src/components/AudioVisualizer.tsx
@@ -14,8 +14,10 @@ const AudioVisualizer: React.FC = () => {
   const materialRef = useRef<THREE.ShaderMaterial | null>(null)
 
   useEffect(() => {
-    getAnalyser()
-    textureRef.current = getFrequencyTexture()
+    const analyser = getAnalyser()
+    if (analyser) {
+      textureRef.current = getFrequencyTexture()
+    }
   }, [])
 
   useFrame(({ clock }) => {

--- a/src/components/ProceduralShapes.tsx
+++ b/src/components/ProceduralShapes.tsx
@@ -32,8 +32,11 @@ const ProceduralShapes: React.FC = () => {
   const prevLevel = useRef(0);
 
   useEffect(() => {
-    analyserRef.current = getAnalyser();
-    dataRef.current = new Uint8Array(analyserRef.current.frequencyBinCount);
+    const analyser = getAnalyser();
+    if (analyser) {
+      analyserRef.current = analyser;
+      dataRef.current = new Uint8Array(analyser.frequencyBinCount);
+    }
   }, []);
 
   useEffect(() => {

--- a/src/components/SceneCanvas.tsx
+++ b/src/components/SceneCanvas.tsx
@@ -67,9 +67,13 @@ const SceneCanvas: React.FC = () => {
 
   useEffect(() => {
     initPhysics()
-    startNote()
-    const timer = setTimeout(() => stopNote(), 2000)
-    return () => clearTimeout(timer)
+    const start = async () => {
+      window.removeEventListener('pointerdown', start)
+      await startNote()
+      setTimeout(() => stopNote(), 2000)
+    }
+    window.addEventListener('pointerdown', start, { once: true })
+    return () => window.removeEventListener('pointerdown', start)
   }, [])
 
   const clamp = useCallback(


### PR DESCRIPTION
## Summary
- ensure physics intro sound only runs after user interaction
- guard audio analyser helpers behind initialization
- handle null analyser in ProceduralShapes and AudioVisualizer

## Testing
- `npm run lint`
- `npx tsc --noEmit`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_685c666284ac8326b0676f0b26f0a84f