### PR TITLE
Fix react-spring imports causing runtime errors

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
         "@heroicons/react": "^2.2.0",
         "@motionone/react": "^10.16.4",
         "@react-spring/three": "^10.0.1",
+        "@react-spring/web": "^10.0.1",
         "@react-three/drei": "^10.3.0",
         "@react-three/fiber": "9.1.2",
         "@react-three/postprocessing": "^3.0.4",
@@ -1331,6 +1332,22 @@
       "resolved": "https://registry.npmjs.org/@react-spring/types/-/types-10.0.1.tgz",
       "integrity": "sha512-Fk1wYVAKL+ZTYK+4YFDpHf3Slsy59pfFFvnnTfRjQQFGlyIo4VejPtDs3CbDiuBjM135YztRyZjIH2VbycB+ZQ==",
       "license": "MIT"
+    },
+    "node_modules/@react-spring/web": {
+      "version": "10.0.1",
+      "resolved": "https://registry.npmjs.org/@react-spring/web/-/web-10.0.1.tgz",
+      "integrity": "sha512-FgQk02OqFrYyJBTTnBTWAU0WPzkHkKXauc6aeexcvATvLapUxwnfGuLlsLYF8BYjEVfkivPT04ziAue6zyRBtQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@react-spring/animated": "~10.0.1",
+        "@react-spring/core": "~10.0.1",
+        "@react-spring/shared": "~10.0.1",
+        "@react-spring/types": "~10.0.1"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
     },
     "node_modules/@react-three/drei": {
       "version": "10.3.0",

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "@heroicons/react": "^2.2.0",
     "@motionone/react": "^10.16.4",
     "@react-spring/three": "^10.0.1",
+    "@react-spring/web": "^10.0.1",
     "@react-three/drei": "^10.3.0",
     "@react-three/fiber": "9.1.2",
     "@react-three/postprocessing": "^3.0.4",

--- a/src/components/PerformanceSelector.tsx
+++ b/src/components/PerformanceSelector.tsx
@@ -1,7 +1,7 @@
 'use client'
 import { useEffect, useState } from 'react'
 import { usePerformanceSettings, PerfLevel } from '@/store/usePerformanceSettings'
-import { a, useSpring } from '@react-spring/three'
+import { a, useSpring } from '@react-spring/web'
 
 export default function PerformanceSelector() {
   const [show, setShow] = useState(false)

--- a/src/components/ShapeEditorPanel.tsx
+++ b/src/components/ShapeEditorPanel.tsx
@@ -1,6 +1,6 @@
 'use client'
 import { Html } from '@react-three/drei'
-import { a, useSpring } from '@react-spring/three'
+import { a, useSpring } from '@react-spring/web'
 import { useSelectedShape } from '@/store/useSelectedShape'
 import { useEffectSettings } from '@/store/useEffectSettings'
 


### PR DESCRIPTION
## Summary
- import `a` from `@react-spring/web` for DOM animations
- add `@react-spring/web` dependency

## Testing
- `npx tsc --noEmit`
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_685cc74f41a0832681f2092a6b28502b