### PR TITLE
Fix audio initialization and hydration issues

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,68 +1,19 @@
 "use client";
-import React, { useEffect } from "react";
-import { Canvas, useThree } from "@react-three/fiber";
-import { Physics } from "@react-three/rapier";
-import { PerspectiveCamera, AdaptiveDpr } from "@react-three/drei";
-import * as THREE from "three";
-import AnimatedGradient from "@/components/AnimatedGradient";
-import MusicalObject from "@/components/MusicalObject";
+import React from "react";
+import dynamic from 'next/dynamic';
 import BottomDrawer from "@/components/BottomDrawer";
-import PlusButton3D from "@/components/PlusButton3D";
 import PerformanceSelector from "@/components/PerformanceSelector";
 import PwaInstallPrompt from "@/components/PwaInstallPrompt";
 import ShapeEditorPanel from "@/components/ShapeEditorPanel";
-import { useSelectedShape } from "@/store/useSelectedShape";
 import ExampleModal from "@/components/ExampleModal";
-import * as Tone from "tone";
-import { playNote } from "@/lib/audio";
-
-function ResizeHandler() {
-  const { camera, gl } = useThree();
-  React.useEffect(() => {
-    const onResize = () => {
-      const w = window.innerWidth;
-      const h = window.innerHeight;
-      if ('aspect' in camera) {
-        (camera as THREE.PerspectiveCamera).aspect = w / h;
-        camera.updateProjectionMatrix();
-      }
-      gl.setSize(w, h);
-    };
-    onResize();
-    window.addEventListener('resize', onResize);
-    return () => window.removeEventListener('resize', onResize);
-  }, [camera, gl]);
-  return null;
-}
+const CanvasScene = dynamic(() => import('../src/components/CanvasScene'), { ssr: false });
 
 export default function Home() {
-  const selected = useSelectedShape((s) => s.selected);
-
-  React.useEffect(() => {
-    const start = async () => {
-      window.removeEventListener('pointerdown', start)
-      await playNote('init')
-    }
-    window.addEventListener('pointerdown', start, { once: true })
-    return () => window.removeEventListener('pointerdown', start)
-  }, [])
 
   return (
     <>
       <div className="h-screen w-screen relative">
-        <Canvas className="w-full h-full" shadows>
-          <AdaptiveDpr pixelated />
-          <AnimatedGradient />
-          <ResizeHandler />
-          <Physics>
-            <PerspectiveCamera makeDefault fov={50} position={[0, 5, 10]} />
-            <ambientLight intensity={0.4} />
-            <directionalLight position={[5, 10, 5]} intensity={0.8} castShadow />
-            <pointLight position={[0, 5, -5]} intensity={0.5} />
-            <MusicalObject />
-          </Physics>
-          <PlusButton3D />
-        </Canvas>
+        <CanvasScene />
       </div>
       <ExampleModal />
       <ShapeEditorPanel />

--- a/src/components/CanvasScene.tsx
+++ b/src/components/CanvasScene.tsx
@@ -1,0 +1,46 @@
+'use client'
+import React from 'react'
+import { Canvas, useThree } from '@react-three/fiber'
+import { Physics } from '@react-three/rapier'
+import { PerspectiveCamera, AdaptiveDpr } from '@react-three/drei'
+import * as THREE from 'three'
+import AnimatedGradient from './AnimatedGradient'
+import MusicalObject from './MusicalObject'
+import PlusButton3D from './PlusButton3D'
+
+function ResizeHandler() {
+  const { camera, gl } = useThree()
+  React.useEffect(() => {
+    const onResize = () => {
+      const w = window.innerWidth
+      const h = window.innerHeight
+      if ('aspect' in camera) {
+        (camera as THREE.PerspectiveCamera).aspect = w / h
+        camera.updateProjectionMatrix()
+      }
+      gl.setSize(w, h)
+    }
+    onResize()
+    window.addEventListener('resize', onResize)
+    return () => window.removeEventListener('resize', onResize)
+  }, [camera, gl])
+  return null
+}
+
+export default function CanvasScene() {
+  return (
+    <Canvas className="w-full h-full" shadows>
+      <AdaptiveDpr pixelated />
+      <AnimatedGradient />
+      <ResizeHandler />
+      <Physics>
+        <PerspectiveCamera makeDefault fov={50} position={[0,5,10]} />
+        <ambientLight intensity={0.4} />
+        <directionalLight position={[5,10,5]} intensity={0.8} castShadow />
+        <pointLight position={[0,5,-5]} intensity={0.5} />
+        <MusicalObject />
+      </Physics>
+      <PlusButton3D />
+    </Canvas>
+  )
+}

--- a/src/components/PlusButton3D.tsx
+++ b/src/components/PlusButton3D.tsx
@@ -5,7 +5,7 @@ import { useRef, useState } from 'react'
 import * as THREE from 'three'
 import { useObjects } from '@/store/useObjects'
 import { useSelectedShape } from '@/store/useSelectedShape'
-import { startNote } from '@/lib/audio'
+import { startAudio } from '@/lib/audio/startAudio'
 import vertex from '@/shaders/plusButton.vert.glsl?raw'
 import fragment from '@/shaders/plusButton.frag.glsl?raw'
 
@@ -35,7 +35,7 @@ export default function PlusButton3D() {
       onClick={async () => {
         if (busy) return
         setBusy(true)
-        await startNote('C5')
+        await startAudio()
         api.start({ distort: 1, scale: 0, config: { duration: 400 }, onRest: () => {
           const id = spawn('note')
           select(id)

--- a/src/lib/audio/startAudio.ts
+++ b/src/lib/audio/startAudio.ts
@@ -1,0 +1,9 @@
+import { enableAudioInit, initAudioEngine, playSpawnSound } from '../audio'
+import { useAudioEngine } from '@/store/useAudioEngine'
+
+export async function startAudio() {
+  enableAudioInit()
+  await initAudioEngine()
+  useAudioEngine.getState().setAudioReady(true)
+  await playSpawnSound()
+}

--- a/src/lib/engine.ts
+++ b/src/lib/engine.ts
@@ -1,1 +1,2 @@
 export * from './audio'
+export * from './audio/startAudio'

--- a/src/store/useAudioEngine.ts
+++ b/src/store/useAudioEngine.ts
@@ -1,0 +1,11 @@
+import { create } from 'zustand'
+
+interface AudioEngineState {
+  audioReady: boolean
+  setAudioReady: (ready: boolean) => void
+}
+
+export const useAudioEngine = create<AudioEngineState>((set) => ({
+  audioReady: false,
+  setAudioReady: (ready) => set({ audioReady: ready })
+}))


### PR DESCRIPTION
## Summary
- start Tone.js after user interaction only
- add startAudio helper and playSpawnSound effect
- defer canvas to a dynamic CanvasScene to avoid hydration mismatches
- manage audio ready state with zustand

## Testing
- `npx tsc --noEmit`
- `npm run lint`
- `npm run build`
- `npm run start`

------
https://chatgpt.com/codex/tasks/task_e_685dae6208d48326b1a0048e2e7832b3