### PR TITLE
Fix Tone.js startup and canvas hydration

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,69 +1,24 @@
 "use client";
-import React, { useEffect } from "react";
-import { Canvas, useThree } from "@react-three/fiber";
-import { Physics } from "@react-three/rapier";
-import { PerspectiveCamera, AdaptiveDpr } from "@react-three/drei";
-import * as THREE from "three";
-import AnimatedGradient from "@/components/AnimatedGradient";
-import MusicalObject from "@/components/MusicalObject";
+import React from "react";
+import dynamic from "next/dynamic";
+import { useSelectedShape } from "@/store/useSelectedShape";
+import ExampleModal from "@/components/ExampleModal";
 import BottomDrawer from "@/components/BottomDrawer";
-import PlusButton3D from "@/components/PlusButton3D";
 import PerformanceSelector from "@/components/PerformanceSelector";
 import PwaInstallPrompt from "@/components/PwaInstallPrompt";
 import ShapeEditorPanel from "@/components/ShapeEditorPanel";
-import { useSelectedShape } from "@/store/useSelectedShape";
-import ExampleModal from "@/components/ExampleModal";
-import * as Tone from "tone";
-import { playNote } from "@/lib/audio";
 
-function ResizeHandler() {
-  const { camera, gl } = useThree();
-  React.useEffect(() => {
-    const onResize = () => {
-      const w = window.innerWidth;
-      const h = window.innerHeight;
-      if ('aspect' in camera) {
-        (camera as THREE.PerspectiveCamera).aspect = w / h;
-        camera.updateProjectionMatrix();
-      }
-      gl.setSize(w, h);
-    };
-    onResize();
-    window.addEventListener('resize', onResize);
-    return () => window.removeEventListener('resize', onResize);
-  }, [camera, gl]);
-  return null;
-}
+const CanvasScene = dynamic(() => import("@/components/CanvasScene"), {
+  ssr: false,
+});
 
 export default function Home() {
-  const selected = useSelectedShape((s) => s.selected);
-
-  React.useEffect(() => {
-    const start = async () => {
-      window.removeEventListener('pointerdown', start)
-      await playNote('init')
-    }
-    window.addEventListener('pointerdown', start, { once: true })
-    return () => window.removeEventListener('pointerdown', start)
-  }, [])
+  // subscribe to selected shape to trigger re-renders
+  useSelectedShape((s) => s.selected);
 
   return (
     <>
-      <div className="h-screen w-screen relative">
-        <Canvas className="w-full h-full" shadows>
-          <AdaptiveDpr pixelated />
-          <AnimatedGradient />
-          <ResizeHandler />
-          <Physics>
-            <PerspectiveCamera makeDefault fov={50} position={[0, 5, 10]} />
-            <ambientLight intensity={0.4} />
-            <directionalLight position={[5, 10, 5]} intensity={0.8} castShadow />
-            <pointLight position={[0, 5, -5]} intensity={0.5} />
-            <MusicalObject />
-          </Physics>
-          <PlusButton3D />
-        </Canvas>
-      </div>
+      <CanvasScene />
       <ExampleModal />
       <ShapeEditorPanel />
       <PerformanceSelector />

--- a/src/components/CanvasScene.tsx
+++ b/src/components/CanvasScene.tsx
@@ -1,0 +1,48 @@
+'use client'
+import React from 'react'
+import { Canvas, useThree } from '@react-three/fiber'
+import { Physics } from '@react-three/rapier'
+import { PerspectiveCamera, AdaptiveDpr } from '@react-three/drei'
+import * as THREE from 'three'
+import AnimatedGradient from './AnimatedGradient'
+import MusicalObject from './MusicalObject'
+import PlusButton3D from './PlusButton3D'
+
+function ResizeHandler() {
+  const { camera, gl } = useThree()
+  React.useEffect(() => {
+    const onResize = () => {
+      const w = window.innerWidth
+      const h = window.innerHeight
+      if ('aspect' in camera) {
+        ;(camera as THREE.PerspectiveCamera).aspect = w / h
+        camera.updateProjectionMatrix()
+      }
+      gl.setSize(w, h)
+    }
+    onResize()
+    window.addEventListener('resize', onResize)
+    return () => window.removeEventListener('resize', onResize)
+  }, [camera, gl])
+  return null
+}
+
+export default function CanvasScene() {
+  return (
+    <div className="h-screen w-screen relative">
+      <Canvas className="w-full h-full" shadows>
+        <AdaptiveDpr pixelated />
+        <AnimatedGradient />
+        <ResizeHandler />
+        <Physics>
+          <PerspectiveCamera makeDefault fov={50} position={[0, 5, 10]} />
+          <ambientLight intensity={0.4} />
+          <directionalLight position={[5, 10, 5]} intensity={0.8} castShadow />
+          <pointLight position={[0, 5, -5]} intensity={0.5} />
+          <MusicalObject />
+        </Physics>
+        <PlusButton3D />
+      </Canvas>
+    </div>
+  )
+}

--- a/src/components/PlusButton3D.tsx
+++ b/src/components/PlusButton3D.tsx
@@ -5,7 +5,7 @@ import { useRef, useState } from 'react'
 import * as THREE from 'three'
 import { useObjects } from '@/store/useObjects'
 import { useSelectedShape } from '@/store/useSelectedShape'
-import { startNote } from '@/lib/audio'
+import { startAudio } from '@/lib/audio/startAudio'
 import vertex from '@/shaders/plusButton.vert.glsl?raw'
 import fragment from '@/shaders/plusButton.frag.glsl?raw'
 
@@ -35,7 +35,7 @@ export default function PlusButton3D() {
       onClick={async () => {
         if (busy) return
         setBusy(true)
-        await startNote('C5')
+        await startAudio()
         api.start({ distort: 1, scale: 0, config: { duration: 400 }, onRest: () => {
           const id = spawn('note')
           select(id)

--- a/src/lib/audio.ts
+++ b/src/lib/audio.ts
@@ -146,6 +146,10 @@ async function initAudioEngine() {
   return initPromise
 }
 
+export async function startAudioEngine() {
+  await initAudioEngine()
+}
+
 function keyOffset(key: string): number {
   const map: Record<string, number> = { C: 0, 'C#': 1, D: 2, Eb: 3, E: 4, F: 5, 'F#': 6, G: 7, Ab: 8, A: 9, Bb: 10, B: 11 }
   return map[key] ?? 0

--- a/src/lib/audio/startAudio.ts
+++ b/src/lib/audio/startAudio.ts
@@ -1,0 +1,8 @@
+import { startAudioEngine, startNote } from '../audio'
+import { useAudioReady } from '@/store/useAudioReady'
+
+export async function startAudio() {
+  await startAudioEngine()
+  useAudioReady.getState().setAudioReady(true)
+  await startNote('C5')
+}

--- a/src/store/useAudioReady.ts
+++ b/src/store/useAudioReady.ts
@@ -1,0 +1,11 @@
+import { create } from 'zustand'
+
+interface AudioReadyState {
+  audioReady: boolean
+  setAudioReady: (ready: boolean) => void
+}
+
+export const useAudioReady = create<AudioReadyState>((set) => ({
+  audioReady: false,
+  setAudioReady: (ready) => set({ audioReady: ready }),
+}))


### PR DESCRIPTION
## Summary
- dynamically load CanvasScene on client
- delay Tone.js init until user clicks plus button
- add `audioReady` Zustand store
- encapsulate startAudio logic

## Testing
- `npx tsc --noEmit`
- `npm run lint`
- `npm run build`
- `npm run start`

------
https://chatgpt.com/codex/tasks/task_e_685dae6208d48326b1a0048e2e7832b3