### PR TITLE
Improve error reporting and add DevCanvas

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -13,6 +13,9 @@ import { safeStringify } from '@/lib/safeStringify'
 export default function RootLayout({ children }: { children: React.ReactNode }) {
   useEffect(() => {
     registerServiceWorker()
+    if (process.env.NODE_ENV !== 'production') {
+      console.log('RootLayout mounted')
+    }
     window.onerror = (_msg, _src, lineno, colno, error) => {
       console.error(
         'Global error:',

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -7,13 +7,19 @@ import PwaInstallPrompt from "@/components/PwaInstallPrompt";
 import ShapeEditorPanel from "@/components/ShapeEditorPanel";
 import ExampleModal from "@/components/ExampleModal";
 const CanvasScene = dynamic(() => import('../src/components/CanvasScene'), { ssr: false });
+const DevCanvas = dynamic(() => import('../src/components/DevCanvas'), { ssr: false })
 
 export default function Home() {
+  const useDevCanvas =
+    typeof window !== 'undefined' &&
+    new URLSearchParams(window.location.search).get('devcanvas') === '1'
+
+  const Scene = useDevCanvas ? DevCanvas : CanvasScene
 
   return (
     <>
       <div className="h-screen w-screen relative">
-        <CanvasScene />
+        <Scene />
       </div>
       <ExampleModal />
       <ShapeEditorPanel />
@@ -21,5 +27,5 @@ export default function Home() {
       <PwaInstallPrompt />
       <BottomDrawer />
     </>
-  );
+  )
 }

--- a/src/components/CanvasScene.tsx
+++ b/src/components/CanvasScene.tsx
@@ -28,6 +28,11 @@ function ResizeHandler() {
 }
 
 export default function CanvasScene() {
+  React.useEffect(() => {
+    if (process.env.NODE_ENV !== 'production') {
+      console.log('CanvasScene mounted')
+    }
+  }, [])
   return (
     <Canvas className="w-full h-full" shadows>
       <AdaptiveDpr pixelated />

--- a/src/components/DevCanvas.tsx
+++ b/src/components/DevCanvas.tsx
@@ -1,0 +1,19 @@
+'use client'
+import React from 'react'
+import { Canvas } from '@react-three/fiber'
+
+export default function DevCanvas() {
+  React.useEffect(() => {
+    if (process.env.NODE_ENV !== 'production') {
+      console.log('DevCanvas mounted')
+    }
+  }, [])
+  return (
+    <Canvas className="w-full h-full">
+      <mesh>
+        <boxGeometry args={[1,1,1]} />
+        <meshBasicMaterial color="hotpink" />
+      </mesh>
+    </Canvas>
+  )
+}

--- a/src/components/ErrorBoundary.tsx
+++ b/src/components/ErrorBoundary.tsx
@@ -9,6 +9,8 @@ interface Props {
 interface State {
   hasError: boolean
   cyclic?: boolean
+  error?: Error
+  errorInfo?: ErrorInfo
 }
 
 class ErrorBoundary extends React.Component<Props, State> {
@@ -32,15 +34,26 @@ class ErrorBoundary extends React.Component<Props, State> {
         componentStack: errorInfo.componentStack,
       })
     )
+    this.setState({ error, errorInfo })
   }
 
   render() {
     if (this.state.hasError) {
+      const isDev = process.env.NODE_ENV !== 'production'
       return (
         <div className={ui.glass} style={{ padding: '1rem', color: 'red' }}>
           {this.state.cyclic
             ? 'Data serialization error—please reload.'
             : 'Something went wrong.'}
+          {isDev && this.state.error && (
+            <pre style={{ whiteSpace: 'pre-wrap' }}>
+              {this.state.error.message}
+              {'\n'}
+              {this.state.error.stack}
+              {'\n'}
+              {this.state.errorInfo?.componentStack}
+            </pre>
+          )}
         </div>
       )
     }

--- a/src/components/MusicalObject.tsx
+++ b/src/components/MusicalObject.tsx
@@ -56,6 +56,9 @@ const MusicalObjectInstances: React.FC = () => {
                   scale={objectConfigs[t].baseScale}
                   onClick={async (e) => {
                     e.stopPropagation()
+                    if (process.env.NODE_ENV !== 'production') {
+                      console.log('Clicked object', obj.id)
+                    }
                     select(obj.id)
                     await triggerSound(obj.type, obj.id)
                   }}


### PR DESCRIPTION
## Summary
- show stacktrace in development builds
- log when RootLayout and CanvasScene mount and on object click
- allow toggling DevCanvas via `?devcanvas=1`
- create DevCanvas for lightweight rendering test

## Testing
- `npm run lint`
- `npx tsc`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_685dbaf1618c83268191e3a9be05583c