### PR TITLE
Improve error visibility and user-triggered audio start

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -40,7 +40,7 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
   return (
     <html lang="en">
       <body className={ui.root}>
-        <ErrorBoundary>
+        <ErrorBoundary verbose>
           <AudioSettingsPanel />
           <PluginLoader />
           {children}

--- a/src/components/ErrorBoundary.tsx
+++ b/src/components/ErrorBoundary.tsx
@@ -5,6 +5,7 @@ import { safeStringify } from '../lib/safeStringify'
 
 interface Props {
   children: ReactNode
+  verbose?: boolean
 }
 interface State {
   hasError: boolean
@@ -45,7 +46,7 @@ class ErrorBoundary extends React.Component<Props, State> {
           {this.state.cyclic
             ? 'Data serialization error—please reload.'
             : 'Something went wrong.'}
-          {isDev && this.state.error && (
+          {(isDev || this.props.verbose) && this.state.error && (
             <pre style={{ whiteSpace: 'pre-wrap' }}>
               {this.state.error.message}
               {'\n'}

--- a/src/components/PlusButton3D.tsx
+++ b/src/components/PlusButton3D.tsx
@@ -5,7 +5,7 @@ import { useRef, useState } from 'react'
 import * as THREE from 'three'
 import { useObjects } from '@/store/useObjects'
 import { useSelectedShape } from '@/store/useSelectedShape'
-import { startAudio } from '@/lib/audio/startAudio'
+import { startAudioContext } from '@/lib/audio'
 import vertex from '@/shaders/plusButton.vert.glsl?raw'
 import fragment from '@/shaders/plusButton.frag.glsl?raw'
 
@@ -35,7 +35,7 @@ export default function PlusButton3D() {
       onClick={async () => {
         if (busy) return
         setBusy(true)
-        await startAudio()
+        await startAudioContext()
         api.start({ distort: 1, scale: 0, config: { duration: 400 }, onRest: () => {
           const id = spawn('note')
           select(id)

--- a/src/lib/audio.ts
+++ b/src/lib/audio.ts
@@ -69,6 +69,17 @@ export function onAudioInit(cb: () => void) {
 export function enableAudioInit() {
   allowInit = true
 }
+
+/**
+ * Resume the AudioContext after a user gesture.
+ */
+export async function startAudioContext() {
+  enableAudioInit()
+  await initAudioEngine()
+  if (process.env.NODE_ENV !== 'production') {
+    console.log('Audio context started')
+  }
+}
 let masterVolumeNode: Volume
 
 let chorus: Chorus

--- a/src/lib/audio/startAudio.ts
+++ b/src/lib/audio/startAudio.ts
@@ -1,9 +1,8 @@
-import { enableAudioInit, initAudioEngine, playSpawnSound } from '../audio'
+import { startAudioContext, playSpawnSound } from '../audio'
 import { useAudioEngine } from '@/store/useAudioEngine'
 
 export async function startAudio() {
-  enableAudioInit()
-  await initAudioEngine()
+  await startAudioContext()
   useAudioEngine.getState().setAudioReady(true)
   await playSpawnSound()
 }


### PR DESCRIPTION
## Summary
- enhance `ErrorBoundary` with a `verbose` mode
- use verbose mode in `app/layout.tsx` to show full stack traces
- expose `startAudioContext()` and log when audio starts
- trigger `startAudioContext` from the plus button
- keep `startAudio` helper but delegate to the new util

## Testing
- `npx tsc --noEmit`
- `npm run lint`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_685dd040d6f08326b102ab17203669c0