### PR TITLE
Fix hydration mismatch and defer audio init

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -237,3 +237,12 @@ Task: CI/CD & Build Validation
 ---
 
 *Last updated: 2025-06-25*
+
+## Agent: Audio Init & Render Safety Agent
+
+### Responsibilities:
+- Ensure Tone.js audio is initialized **only after user interaction**
+- Refactor any `AudioContext` or Tone.js logic out of SSR scope
+- Audit React hook usage for hydration safety (no conditional hooks or SSR-incompatible patterns)
+- Guarantee compatibility with both `npm run dev` and `npm run build`
+- Wrap all browser-dependent components with dynamic import or `"use client"` guard

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -4,6 +4,7 @@ import '../src/styles/globals.css'
 import ui from '../src/styles/ui.module.css'
 import React, { useEffect } from 'react'
 import { registerServiceWorker } from '@/lib/registerServiceWorker'
+import { loadObjectsFromStorage } from '@/store/useObjects'
 import PluginLoader from "./PluginLoader"
 import AudioSettingsPanel from '@/components/AudioSettingsPanel'
 import ErrorBoundary from '@/components/ErrorBoundary'
@@ -13,6 +14,7 @@ import { safeStringify } from '@/lib/safeStringify'
 export default function RootLayout({ children }: { children: React.ReactNode }) {
   useEffect(() => {
     registerServiceWorker()
+    loadObjectsFromStorage()
     if (process.env.NODE_ENV !== 'production') {
       console.log('RootLayout mounted')
     }

--- a/docs/audio-init.md
+++ b/docs/audio-init.md
@@ -1,0 +1,9 @@
+# Audio Initialization Guide
+
+This project defers loading and starting Tone.js until the user interacts with the page.
+
+1. `startAudio()` lives in `src/lib/audio/startAudio.ts` and is triggered by clicking the plus button.
+2. The function lazily imports Tone.js and calls `Tone.start()` after user input.
+3. `initAudioEngine()` sets up synths and effects only once, guarded by a flag.
+4. Components must avoid touching Tone.js or `AudioContext` at module scope. Import audio helpers dynamically or inside callbacks.
+5. Call `startAudio()` from user gesture handlers to ensure browsers allow audio playback.

--- a/public/favicon.ico
+++ b/public/favicon.ico
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64">
+  <rect width="64" height="64" fill="#111"/>
+  <circle cx="32" cy="32" r="20" fill="#4fa3ff"/>
+</svg>

--- a/src/components/CanvasScene.tsx
+++ b/src/components/CanvasScene.tsx
@@ -1,5 +1,5 @@
 'use client'
-import React from 'react'
+import React, { Suspense } from 'react'
 import { Canvas, useThree } from '@react-three/fiber'
 import { Physics } from '@react-three/rapier'
 import { PerspectiveCamera, AdaptiveDpr } from '@react-three/drei'
@@ -43,7 +43,9 @@ export default function CanvasScene() {
         <ambientLight intensity={0.4} />
         <directionalLight position={[5,10,5]} intensity={0.8} castShadow />
         <pointLight position={[0,5,-5]} intensity={0.5} />
-        <MusicalObject />
+        <Suspense fallback={null}>
+          <MusicalObject />
+        </Suspense>
       </Physics>
       <PlusButton3D />
     </Canvas>

--- a/src/store/useObjects.ts
+++ b/src/store/useObjects.ts
@@ -24,9 +24,7 @@ interface ObjectState {
 }
 
 export const useObjects = create<ObjectState>((set, get) => ({
-  objects: typeof window !== 'undefined'
-    ? JSON.parse(localStorage.getItem('objects') || '[]')
-    : [],
+  objects: [],
   spawn: (type: ObjectType, position?: [number, number, number]) => {
     const id = Date.now().toString()
     const newObj: MusicalObject = {
@@ -49,3 +47,17 @@ export const useObjects = create<ObjectState>((set, get) => ({
     return id
   },
 }))
+
+export function loadObjectsFromStorage() {
+  if (typeof window === 'undefined') return
+  try {
+    const stored = localStorage.getItem('objects')
+    if (!stored) return
+    const list: MusicalObject[] = JSON.parse(stored)
+    useObjects.setState({ objects: list })
+    list.forEach((obj) => addBody(obj.id, obj.position))
+    ;(window as any).__objects__ = list
+  } catch (err) {
+    console.error('Failed to load objects from storage', err)
+  }
+}


### PR DESCRIPTION
## Summary
- prevent SSR/localStorage mismatch by loading objects after mount
- support deferred audio init by documenting startup
- wrap MusicalObject in Suspense for safety
- auto-load saved objects on layout mount
- add favicon.ico
- document audio init responsibilities in AGENTS guide

## Testing
- `npm run lint`
- `npx tsc --noEmit`
- `npm run build`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_685df13bafa483268518dbc040d26255