### PR TITLE
Add paths-filter workflow for PRs

### DIFF
--- a/.github/workflows/paths-filter.yml
+++ b/.github/workflows/paths-filter.yml
@@ -1,0 +1,31 @@
+name: Path Filters
+
+on:
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  detect-changes:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Filter changes
+        id: filter
+        uses: dorny/paths-filter@v3
+        with:
+          filters: |
+            frontend:
+              - 'frontend/**'
+            backend:
+              - 'backend/**'
+
+      - name: Echo matched filters
+        run: |
+          echo "Frontend changed: ${{ steps.filter.outputs.frontend }}"
+          echo "Backend changed: ${{ steps.filter.outputs.backend }}"
+


### PR DESCRIPTION
## Summary
- detect changes in `frontend/**` and `backend/**` via `dorny/paths-filter`
- run only on pull requests targeting `main`
- checkout repository before filtering and fetch full history
- echo which filter matched

## Testing
- `npm ci`
- `npx tsc --noEmit`
- `npm run lint`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6865c520d1248326bde9b09bc6d0e06c