### PR TITLE
Fix npm peer deps in Docker build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,7 @@ COPY package.json package-lock.json .
 
 RUN --mount=type=cache,target=/root/.npm \
     --mount=type=cache,target=/root/.cache \
-    npm ci
+    npm ci --legacy-peer-deps
 
 FROM node:18.20.8-alpine AS builder
 WORKDIR /app


### PR DESCRIPTION
## Summary
- use `--legacy-peer-deps` during Docker image build

## Testing
- `npx tsc --noEmit`
- `npm run lint`
- `npm run build`
- `npx next start`

------
https://chatgpt.com/codex/tasks/task_e_68660c92bddc832691f44d5ae676fe26