### PR TITLE
Fix lint warning and update Docker base

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,12 +1,14 @@
 # syntax=docker/dockerfile:1.4
 # Optimized multi-stage Dockerfile for Next.js production build
 
-FROM node:18.20.8-alpine AS deps
+FROM node:18.20.8-bullseye-slim AS deps
 WORKDIR /app
 
 # Install system packages first to leverage caching
-RUN apk add --no-cache python3 make g++ \
-    && npm install -g npm@10.8.2
+RUN apt-get update && apt-get install -y --no-install-recommends \
+      python3 make g++ \
+    && npm install -g npm@10.8.2 \
+    && rm -rf /var/lib/apt/lists/*
 
 # Copy only package manifests to install dependencies
 COPY package.json package-lock.json .
@@ -15,7 +17,7 @@ RUN --mount=type=cache,target=/root/.npm \
     --mount=type=cache,target=/root/.cache \
     npm ci --legacy-peer-deps
 
-FROM node:18.20.8-alpine AS builder
+FROM node:18.20.8-bullseye-slim AS builder
 WORKDIR /app
 
 COPY --from=deps /app/node_modules ./node_modules
@@ -23,7 +25,7 @@ COPY . .
 
 RUN npm run build && npm prune --production
 
-FROM node:18.20.8-alpine AS runner
+FROM node:18.20.8-bullseye-slim AS runner
 WORKDIR /app
 ENV NODE_ENV=production
 

--- a/src/components/CanvasScene.tsx
+++ b/src/components/CanvasScene.tsx
@@ -46,7 +46,7 @@ export default function CanvasScene() {
       }
     })()
     return () => { cancelled = true }
-  }, [])
+  }, [setPerf])
   return (
     <Canvas className="w-full h-full" shadows gl={renderer ?? undefined}>
       <AdaptiveDpr pixelated />


### PR DESCRIPTION
## Summary
- add `setPerf` to dependency array in `CanvasScene`
- use Debian-based Node images so Playwright dependencies install correctly

## Testing
- `npx next@15.3.4 lint`

------
https://chatgpt.com/codex/tasks/task_e_6866145da3388326a6d7db52c11b7b00