### PR TITLE
Fix pipeline warnings and update Docker image

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -23,7 +23,6 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
-          single-branch: true
 
       - name: Determine changed paths
         id: changes

--- a/.gitignore
+++ b/.gitignore
@@ -10,5 +10,6 @@ node_modules/
 
 # Lock files
 package-lock.json
-.buildcache/
+.buildcache/*
+!.buildcache/.gitkeep
 tsconfig.tsbuildinfo

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,39 +1,32 @@
 # syntax=docker/dockerfile:1.4
-# Optimized multi-stage Dockerfile for Next.js production build
+# Multi-stage Dockerfile built on Ubuntu 22.04 for Next.js
 
-FROM node:20.17.0-bullseye-slim AS deps
+FROM ubuntu:22.04 AS base
 WORKDIR /app
 
-# Install system packages first to leverage caching
+# Install Node 20 and required build dependencies
 RUN apt-get update && apt-get install -y --no-install-recommends \
-      python3 make g++ \
+    curl gnupg ca-certificates python3 make g++ \
+    libnss3 libatk-bridge2.0-0 libxss1 libgtk-3-0 libx11-xcb1 \
+    && curl -fsSL https://deb.nodesource.com/setup_20.x | bash - \
+    && apt-get install -y nodejs \
     && npm install -g npm@11.4.2 \
     && rm -rf /var/lib/apt/lists/*
 
-# Copy only package manifests to install dependencies
-COPY package.json package-lock.json .
-
+FROM base AS deps
+COPY package.json package-lock.json ./
 RUN --mount=type=cache,target=/root/.npm \
-    --mount=type=cache,target=/root/.cache \
     npm ci --legacy-peer-deps
 
-FROM node:20.17.0-bullseye-slim AS builder
-WORKDIR /app
-
+FROM base AS builder
 COPY --from=deps /app/node_modules ./node_modules
 COPY . .
+RUN npm run build && npm prune --omit=dev
 
-RUN npm run build && npm prune --production
-
-FROM node:20.17.0-bullseye-slim AS runner
-WORKDIR /app
+FROM base AS runner
 ENV NODE_ENV=production
 ENV LOG_DIR=/app/logs
-
 RUN mkdir -p "$LOG_DIR"
-
 COPY --from=builder /app .
-
 EXPOSE 3000
-
 CMD ["npm", "run", "start"]

--- a/README.md
+++ b/README.md
@@ -166,8 +166,14 @@ appear in Unraid's Docker logs UI.
    docker run -d --name interactive-music-web \
      --restart unless-stopped \
      -p 31415:3000 \
-     interactive-music-web:<tag>
-   ```
+    interactive-music-web:<tag>
+  ```
+
+### Swap Limit Warning
+If Docker logs show `No swap limit support`, your host kernel does not enable
+swap accounting. You can enable it via your Docker daemon settings on newer
+kernels. Older distributions may not support this feature; the warning can be
+ignored in that case.
 
 ---
 


### PR DESCRIPTION
## Summary
- upgrade Dockerfile to Ubuntu 22.04 with Node 20
- ignore build cache contents and track `.gitkeep`
- remove deprecated `single-branch` flag from deploy workflow
- document swap accounting warning in README

## Testing
- `npx tsc --noEmit`
- `npm run lint`
- `npm run build`
- `npm test` *(fails if port already in use but succeeds here)*

------
https://chatgpt.com/codex/tasks/task_e_6866defee4b08326a0b9d820f1690126