### PR TITLE
Fix infinite renderer loop causing React error 185

### DIFF
--- a/src/components/CanvasScene.tsx
+++ b/src/components/CanvasScene.tsx
@@ -32,23 +32,27 @@ function ResizeHandler() {
 }
 
 export default function CanvasScene() {
-  const [renderer, setRenderer] = React.useState<THREE.WebGLRenderer | null>(null)
-  const setPerf = usePerformanceSettings(s => s.setLevel)
+  const rendererRef = React.useRef<THREE.WebGLRenderer | null>(null)
+  const [ready, setReady] = React.useState(false)
+  const setPerf = usePerformanceSettings((s) => s.setLevel)
   React.useEffect(() => {
     let cancelled = false
+    if (rendererRef.current) return
     ;(async () => {
       const gpu = await getGPUTier()
       if (gpu && gpu.tier < 1) setPerf('low')
       else if (gpu && gpu.tier < 3) setPerf('medium')
       if (!cancelled && typeof navigator !== 'undefined' && (navigator as any).gpu) {
-        const r = new WebGPURenderer({ antialias: true })
-        setRenderer(r as unknown as THREE.WebGLRenderer)
+        rendererRef.current = new WebGPURenderer({ antialias: true }) as unknown as THREE.WebGLRenderer
+        setReady(true)
       }
     })()
-    return () => { cancelled = true }
+    return () => {
+      cancelled = true
+    }
   }, [setPerf])
   return (
-    <Canvas className="w-full h-full" shadows gl={renderer ?? undefined}>
+    <Canvas className="w-full h-full" shadows gl={rendererRef.current ?? undefined}>
       <AdaptiveDpr pixelated />
       <AnimatedGradient />
       <ResizeHandler />


### PR DESCRIPTION
## Summary
- avoid recreating renderer every mount in `CanvasScene`
- store the WebGPU renderer in a ref and only create it once

## Testing
- `npx tsc --noEmit`
- `npm run lint`
- `npm run build`
- `npm run start`

------
https://chatgpt.com/codex/tasks/task_e_6866eec2e9c0832682c30199e62ababf