### PR TITLE
Add interactive overlay to lazy load scenes

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -6,23 +6,36 @@ import PerformanceSelector from "@/components/PerformanceSelector";
 import PwaInstallPrompt from "@/components/PwaInstallPrompt";
 import ShapeEditorPanel from "@/components/ShapeEditorPanel";
 import ExampleModal from "@/components/ExampleModal";
+import StartOverlay from "@/components/StartOverlay";
+import { startAudio } from "@/lib/engine";
 const CanvasScene = dynamic(() => import('../src/components/CanvasScene'), { ssr: false });
 const DevCanvas = dynamic(() => import('../src/components/DevCanvas'), { ssr: false })
 
 export default function Home() {
   const [Scene, setScene] = React.useState(() => CanvasScene)
+  const [started, setStarted] = React.useState(false)
   React.useEffect(() => {
     const useDev = new URLSearchParams(window.location.search).get('devcanvas') === '1'
     if (useDev) setScene(() => DevCanvas)
   }, [])
 
+  const handleStart = React.useCallback(async () => {
+    await startAudio()
+    setStarted(true)
+  }, [])
+
   return (
     <>
-      <div className="h-screen w-screen relative">
-        <Scene />
-      </div>
+      {!started && <StartOverlay onFinish={handleStart} />}
+      {started && (
+        <>
+          <div className="h-screen w-screen relative">
+            <Scene />
+          </div>
+          <ShapeEditorPanel />
+        </>
+      )}
       <ExampleModal />
-      <ShapeEditorPanel />
       <PerformanceSelector />
       <PwaInstallPrompt />
       <BottomDrawer />

--- a/package-lock.json
+++ b/package-lock.json
@@ -31,10 +31,13 @@
         "react": "19.1.0",
         "react-dom": "19.1.0",
         "react-knob-headless": "^0.4.0",
+        "react-tsparticles": "^2.12.2",
         "simple-peer": "^9.11.1",
         "socket.io-client": "^4.8.1",
         "three": "^0.178.0",
         "tone": "^15.1.22",
+        "tsparticles": "^2.12.0",
+        "tsparticles-engine": "^2.12.0",
         "zustand": "^5.0.6"
       },
       "devDependencies": {
@@ -10886,6 +10889,34 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/react-tsparticles": {
+      "version": "2.12.2",
+      "resolved": "https://registry.npmjs.org/react-tsparticles/-/react-tsparticles-2.12.2.tgz",
+      "integrity": "sha512-/nrEbyL8UROXKIMXe+f+LZN2ckvkwV2Qa+GGe/H26oEIc+wq/ybSG9REDwQiSt2OaDQGu0MwmA4BKmkL6wAWcA==",
+      "deprecated": "@tsparticles/react is the new version, please use that",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/matteobruni"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/tsparticles"
+        },
+        {
+          "type": "buymeacoffee",
+          "url": "https://www.buymeacoffee.com/matteobruni"
+        }
+      ],
+      "hasInstallScript": true,
+      "license": "MIT",
+      "dependencies": {
+        "tsparticles-engine": "^2.12.0"
+      },
+      "peerDependencies": {
+        "react": ">=16"
+      }
+    },
     "node_modules/react-use-measure": {
       "version": "2.1.7",
       "resolved": "https://registry.npmjs.org/react-use-measure/-/react-use-measure-2.1.7.tgz",
@@ -12816,6 +12847,565 @@
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
       "license": "0BSD"
+    },
+    "node_modules/tsparticles": {
+      "version": "2.12.0",
+      "resolved": "https://registry.npmjs.org/tsparticles/-/tsparticles-2.12.0.tgz",
+      "integrity": "sha512-aw77llkaEhcKYUHuRlggA6SB1Dpa814/nrStp9USGiDo5QwE1Ckq30QAgdXU6GRvnblUFsiO750ZuLQs5Y0tVw==",
+      "deprecated": "tsParticles v3 is out, it contains breaking changes and it's recommended to migrate to that version with fixes and new features",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/matteobruni"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/tsparticles"
+        },
+        {
+          "type": "buymeacoffee",
+          "url": "https://www.buymeacoffee.com/matteobruni"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "tsparticles-engine": "^2.12.0",
+        "tsparticles-interaction-external-trail": "^2.12.0",
+        "tsparticles-plugin-absorbers": "^2.12.0",
+        "tsparticles-plugin-emitters": "^2.12.0",
+        "tsparticles-slim": "^2.12.0",
+        "tsparticles-updater-destroy": "^2.12.0",
+        "tsparticles-updater-roll": "^2.12.0",
+        "tsparticles-updater-tilt": "^2.12.0",
+        "tsparticles-updater-twinkle": "^2.12.0",
+        "tsparticles-updater-wobble": "^2.12.0"
+      }
+    },
+    "node_modules/tsparticles-basic": {
+      "version": "2.12.0",
+      "resolved": "https://registry.npmjs.org/tsparticles-basic/-/tsparticles-basic-2.12.0.tgz",
+      "integrity": "sha512-pN6FBpL0UsIUXjYbiui5+IVsbIItbQGOlwyGV55g6IYJBgdTNXgFX0HRYZGE9ZZ9psEXqzqwLM37zvWnb5AG9g==",
+      "deprecated": "starting from tsparticles v3 the packages are now moved to @tsparticles/package-name instead of tsparticles-package-name",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/matteobruni"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/tsparticles"
+        },
+        {
+          "type": "buymeacoffee",
+          "url": "https://www.buymeacoffee.com/matteobruni"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "tsparticles-engine": "^2.12.0",
+        "tsparticles-move-base": "^2.12.0",
+        "tsparticles-shape-circle": "^2.12.0",
+        "tsparticles-updater-color": "^2.12.0",
+        "tsparticles-updater-opacity": "^2.12.0",
+        "tsparticles-updater-out-modes": "^2.12.0",
+        "tsparticles-updater-size": "^2.12.0"
+      }
+    },
+    "node_modules/tsparticles-engine": {
+      "version": "2.12.0",
+      "resolved": "https://registry.npmjs.org/tsparticles-engine/-/tsparticles-engine-2.12.0.tgz",
+      "integrity": "sha512-ZjDIYex6jBJ4iMc9+z0uPe7SgBnmb6l+EJm83MPIsOny9lPpetMsnw/8YJ3xdxn8hV+S3myTpTN1CkOVmFv0QQ==",
+      "deprecated": "starting from tsparticles v3 the packages are now moved to @tsparticles/package-name instead of tsparticles-package-name",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/matteobruni"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/tsparticles"
+        },
+        {
+          "type": "buymeacoffee",
+          "url": "https://www.buymeacoffee.com/matteobruni"
+        }
+      ],
+      "hasInstallScript": true,
+      "license": "MIT"
+    },
+    "node_modules/tsparticles-interaction-external-attract": {
+      "version": "2.12.0",
+      "resolved": "https://registry.npmjs.org/tsparticles-interaction-external-attract/-/tsparticles-interaction-external-attract-2.12.0.tgz",
+      "integrity": "sha512-0roC6D1QkFqMVomcMlTaBrNVjVOpyNzxIUsjMfshk2wUZDAvTNTuWQdUpmsLS4EeSTDN3rzlGNnIuuUQqyBU5w==",
+      "deprecated": "starting from tsparticles v3 the packages are now moved to @tsparticles/package-name instead of tsparticles-package-name",
+      "license": "MIT",
+      "dependencies": {
+        "tsparticles-engine": "^2.12.0"
+      }
+    },
+    "node_modules/tsparticles-interaction-external-bounce": {
+      "version": "2.12.0",
+      "resolved": "https://registry.npmjs.org/tsparticles-interaction-external-bounce/-/tsparticles-interaction-external-bounce-2.12.0.tgz",
+      "integrity": "sha512-MMcqKLnQMJ30hubORtdq+4QMldQ3+gJu0bBYsQr9BsThsh8/V0xHc1iokZobqHYVP5tV77mbFBD8Z7iSCf0TMQ==",
+      "deprecated": "starting from tsparticles v3 the packages are now moved to @tsparticles/package-name instead of tsparticles-package-name",
+      "license": "MIT",
+      "dependencies": {
+        "tsparticles-engine": "^2.12.0"
+      }
+    },
+    "node_modules/tsparticles-interaction-external-bubble": {
+      "version": "2.12.0",
+      "resolved": "https://registry.npmjs.org/tsparticles-interaction-external-bubble/-/tsparticles-interaction-external-bubble-2.12.0.tgz",
+      "integrity": "sha512-5kImCSCZlLNccXOHPIi2Yn+rQWTX3sEa/xCHwXW19uHxtILVJlnAweayc8+Zgmb7mo0DscBtWVFXHPxrVPFDUA==",
+      "deprecated": "starting from tsparticles v3 the packages are now moved to @tsparticles/package-name instead of tsparticles-package-name",
+      "license": "MIT",
+      "dependencies": {
+        "tsparticles-engine": "^2.12.0"
+      }
+    },
+    "node_modules/tsparticles-interaction-external-connect": {
+      "version": "2.12.0",
+      "resolved": "https://registry.npmjs.org/tsparticles-interaction-external-connect/-/tsparticles-interaction-external-connect-2.12.0.tgz",
+      "integrity": "sha512-ymzmFPXz6AaA1LAOL5Ihuy7YSQEW8MzuSJzbd0ES13U8XjiU3HlFqlH6WGT1KvXNw6WYoqrZt0T3fKxBW3/C3A==",
+      "deprecated": "starting from tsparticles v3 the packages are now moved to @tsparticles/package-name instead of tsparticles-package-name",
+      "license": "MIT",
+      "dependencies": {
+        "tsparticles-engine": "^2.12.0"
+      }
+    },
+    "node_modules/tsparticles-interaction-external-grab": {
+      "version": "2.12.0",
+      "resolved": "https://registry.npmjs.org/tsparticles-interaction-external-grab/-/tsparticles-interaction-external-grab-2.12.0.tgz",
+      "integrity": "sha512-iQF/A947hSfDNqAjr49PRjyQaeRkYgTYpfNmAf+EfME8RsbapeP/BSyF6mTy0UAFC0hK2A2Hwgw72eT78yhXeQ==",
+      "deprecated": "starting from tsparticles v3 the packages are now moved to @tsparticles/package-name instead of tsparticles-package-name",
+      "license": "MIT",
+      "dependencies": {
+        "tsparticles-engine": "^2.12.0"
+      }
+    },
+    "node_modules/tsparticles-interaction-external-pause": {
+      "version": "2.12.0",
+      "resolved": "https://registry.npmjs.org/tsparticles-interaction-external-pause/-/tsparticles-interaction-external-pause-2.12.0.tgz",
+      "integrity": "sha512-4SUikNpsFROHnRqniL+uX2E388YTtfRWqqqZxRhY0BrijH4z04Aii3YqaGhJxfrwDKkTQlIoM2GbFT552QZWjw==",
+      "deprecated": "starting from tsparticles v3 the packages are now moved to @tsparticles/package-name instead of tsparticles-package-name",
+      "license": "MIT",
+      "dependencies": {
+        "tsparticles-engine": "^2.12.0"
+      }
+    },
+    "node_modules/tsparticles-interaction-external-push": {
+      "version": "2.12.0",
+      "resolved": "https://registry.npmjs.org/tsparticles-interaction-external-push/-/tsparticles-interaction-external-push-2.12.0.tgz",
+      "integrity": "sha512-kqs3V0dgDKgMoeqbdg+cKH2F+DTrvfCMrPF1MCCUpBCqBiH+TRQpJNNC86EZYHfNUeeLuIM3ttWwIkk2hllR/Q==",
+      "deprecated": "starting from tsparticles v3 the packages are now moved to @tsparticles/package-name instead of tsparticles-package-name",
+      "license": "MIT",
+      "dependencies": {
+        "tsparticles-engine": "^2.12.0"
+      }
+    },
+    "node_modules/tsparticles-interaction-external-remove": {
+      "version": "2.12.0",
+      "resolved": "https://registry.npmjs.org/tsparticles-interaction-external-remove/-/tsparticles-interaction-external-remove-2.12.0.tgz",
+      "integrity": "sha512-2eNIrv4m1WB2VfSVj46V2L/J9hNEZnMgFc+A+qmy66C8KzDN1G8aJUAf1inW8JVc0lmo5+WKhzex4X0ZSMghBg==",
+      "deprecated": "starting from tsparticles v3 the packages are now moved to @tsparticles/package-name instead of tsparticles-package-name",
+      "license": "MIT",
+      "dependencies": {
+        "tsparticles-engine": "^2.12.0"
+      }
+    },
+    "node_modules/tsparticles-interaction-external-repulse": {
+      "version": "2.12.0",
+      "resolved": "https://registry.npmjs.org/tsparticles-interaction-external-repulse/-/tsparticles-interaction-external-repulse-2.12.0.tgz",
+      "integrity": "sha512-rSzdnmgljeBCj5FPp4AtGxOG9TmTsK3AjQW0vlyd1aG2O5kSqFjR+FuT7rfdSk9LEJGH5SjPFE6cwbuy51uEWA==",
+      "deprecated": "starting from tsparticles v3 the packages are now moved to @tsparticles/package-name instead of tsparticles-package-name",
+      "license": "MIT",
+      "dependencies": {
+        "tsparticles-engine": "^2.12.0"
+      }
+    },
+    "node_modules/tsparticles-interaction-external-slow": {
+      "version": "2.12.0",
+      "resolved": "https://registry.npmjs.org/tsparticles-interaction-external-slow/-/tsparticles-interaction-external-slow-2.12.0.tgz",
+      "integrity": "sha512-2IKdMC3om7DttqyroMtO//xNdF0NvJL/Lx7LDo08VpfTgJJozxU+JAUT8XVT7urxhaDzbxSSIROc79epESROtA==",
+      "deprecated": "starting from tsparticles v3 the packages are now moved to @tsparticles/package-name instead of tsparticles-package-name",
+      "license": "MIT",
+      "dependencies": {
+        "tsparticles-engine": "^2.12.0"
+      }
+    },
+    "node_modules/tsparticles-interaction-external-trail": {
+      "version": "2.12.0",
+      "resolved": "https://registry.npmjs.org/tsparticles-interaction-external-trail/-/tsparticles-interaction-external-trail-2.12.0.tgz",
+      "integrity": "sha512-LKSapU5sPTaZqYx+y5VJClj0prlV7bswplSFQaIW1raXkvsk45qir2AVcpP5JUhZSFSG+SwsHr+qCgXhNeN1KA==",
+      "deprecated": "starting from tsparticles v3 the packages are now moved to @tsparticles/package-name instead of tsparticles-package-name",
+      "license": "MIT",
+      "dependencies": {
+        "tsparticles-engine": "^2.12.0"
+      }
+    },
+    "node_modules/tsparticles-interaction-particles-attract": {
+      "version": "2.12.0",
+      "resolved": "https://registry.npmjs.org/tsparticles-interaction-particles-attract/-/tsparticles-interaction-particles-attract-2.12.0.tgz",
+      "integrity": "sha512-Hl8qwuwF9aLq3FOkAW+Zomu7Gb8IKs6Y3tFQUQScDmrrSCaeRt2EGklAiwgxwgntmqzL7hbMWNx06CHHcUQKdQ==",
+      "deprecated": "starting from tsparticles v3 the packages are now moved to @tsparticles/package-name instead of tsparticles-package-name",
+      "license": "MIT",
+      "dependencies": {
+        "tsparticles-engine": "^2.12.0"
+      }
+    },
+    "node_modules/tsparticles-interaction-particles-collisions": {
+      "version": "2.12.0",
+      "resolved": "https://registry.npmjs.org/tsparticles-interaction-particles-collisions/-/tsparticles-interaction-particles-collisions-2.12.0.tgz",
+      "integrity": "sha512-Se9nPWlyPxdsnHgR6ap4YUImAu3W5MeGKJaQMiQpm1vW8lSMOUejI1n1ioIaQth9weKGKnD9rvcNn76sFlzGBA==",
+      "deprecated": "starting from tsparticles v3 the packages are now moved to @tsparticles/package-name instead of tsparticles-package-name",
+      "license": "MIT",
+      "dependencies": {
+        "tsparticles-engine": "^2.12.0"
+      }
+    },
+    "node_modules/tsparticles-interaction-particles-links": {
+      "version": "2.12.0",
+      "resolved": "https://registry.npmjs.org/tsparticles-interaction-particles-links/-/tsparticles-interaction-particles-links-2.12.0.tgz",
+      "integrity": "sha512-e7I8gRs4rmKfcsHONXMkJnymRWpxHmeaJIo4g2NaDRjIgeb2AcJSWKWZvrsoLnm7zvaf/cMQlbN6vQwCixYq3A==",
+      "deprecated": "starting from tsparticles v3 the packages are now moved to @tsparticles/package-name instead of tsparticles-package-name",
+      "license": "MIT",
+      "dependencies": {
+        "tsparticles-engine": "^2.12.0"
+      }
+    },
+    "node_modules/tsparticles-move-base": {
+      "version": "2.12.0",
+      "resolved": "https://registry.npmjs.org/tsparticles-move-base/-/tsparticles-move-base-2.12.0.tgz",
+      "integrity": "sha512-oSogCDougIImq+iRtIFJD0YFArlorSi8IW3HD2gO3USkH+aNn3ZqZNTqp321uB08K34HpS263DTbhLHa/D6BWw==",
+      "deprecated": "starting from tsparticles v3 the packages are now moved to @tsparticles/package-name instead of tsparticles-package-name",
+      "license": "MIT",
+      "dependencies": {
+        "tsparticles-engine": "^2.12.0"
+      }
+    },
+    "node_modules/tsparticles-move-parallax": {
+      "version": "2.12.0",
+      "resolved": "https://registry.npmjs.org/tsparticles-move-parallax/-/tsparticles-move-parallax-2.12.0.tgz",
+      "integrity": "sha512-58CYXaX8Ih5rNtYhpnH0YwU4Ks7gVZMREGUJtmjhuYN+OFr9FVdF3oDIJ9N6gY5a5AnAKz8f5j5qpucoPRcYrQ==",
+      "deprecated": "starting from tsparticles v3 the packages are now moved to @tsparticles/package-name instead of tsparticles-package-name",
+      "license": "MIT",
+      "dependencies": {
+        "tsparticles-engine": "^2.12.0"
+      }
+    },
+    "node_modules/tsparticles-particles.js": {
+      "version": "2.12.0",
+      "resolved": "https://registry.npmjs.org/tsparticles-particles.js/-/tsparticles-particles.js-2.12.0.tgz",
+      "integrity": "sha512-LyOuvYdhbUScmA4iDgV3LxA0HzY1DnOwQUy3NrPYO393S2YwdDjdwMod6Btq7EBUjg9FVIh+sZRizgV5elV2dg==",
+      "deprecated": "starting from tsparticles v3 the packages are now moved to @tsparticles/package-name instead of tsparticles-package-name",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/matteobruni"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/tsparticles"
+        },
+        {
+          "type": "buymeacoffee",
+          "url": "https://www.buymeacoffee.com/matteobruni"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "tsparticles-engine": "^2.12.0"
+      }
+    },
+    "node_modules/tsparticles-plugin-absorbers": {
+      "version": "2.12.0",
+      "resolved": "https://registry.npmjs.org/tsparticles-plugin-absorbers/-/tsparticles-plugin-absorbers-2.12.0.tgz",
+      "integrity": "sha512-2CkPreaXHrE5VzFlxUKLeRB5t66ff+3jwLJoDFgQcp+R4HOEITo0bBZv2DagGP0QZdYN4grpnQzRBVdB4d1rWA==",
+      "deprecated": "starting from tsparticles v3 the packages are now moved to @tsparticles/package-name instead of tsparticles-package-name",
+      "license": "MIT",
+      "dependencies": {
+        "tsparticles-engine": "^2.12.0"
+      }
+    },
+    "node_modules/tsparticles-plugin-easing-quad": {
+      "version": "2.12.0",
+      "resolved": "https://registry.npmjs.org/tsparticles-plugin-easing-quad/-/tsparticles-plugin-easing-quad-2.12.0.tgz",
+      "integrity": "sha512-2mNqez5pydDewMIUWaUhY5cNQ80IUOYiujwG6qx9spTq1D6EEPLbRNAEL8/ecPdn2j1Um3iWSx6lo340rPkv4Q==",
+      "deprecated": "starting from tsparticles v3 the packages are now moved to @tsparticles/package-name instead of tsparticles-package-name",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/matteobruni"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/tsparticles"
+        },
+        {
+          "type": "buymeacoffee",
+          "url": "https://www.buymeacoffee.com/matteobruni"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "tsparticles-engine": "^2.12.0"
+      }
+    },
+    "node_modules/tsparticles-plugin-emitters": {
+      "version": "2.12.0",
+      "resolved": "https://registry.npmjs.org/tsparticles-plugin-emitters/-/tsparticles-plugin-emitters-2.12.0.tgz",
+      "integrity": "sha512-fbskYnaXWXivBh9KFReVCfqHdhbNQSK2T+fq2qcGEWpwtDdgujcaS1k2Q/xjZnWNMfVesik4IrqspcL51gNdSA==",
+      "deprecated": "starting from tsparticles v3 the packages are now moved to @tsparticles/package-name instead of tsparticles-package-name",
+      "license": "MIT",
+      "dependencies": {
+        "tsparticles-engine": "^2.12.0"
+      }
+    },
+    "node_modules/tsparticles-shape-circle": {
+      "version": "2.12.0",
+      "resolved": "https://registry.npmjs.org/tsparticles-shape-circle/-/tsparticles-shape-circle-2.12.0.tgz",
+      "integrity": "sha512-L6OngbAlbadG7b783x16ns3+SZ7i0SSB66M8xGa5/k+YcY7zm8zG0uPt1Hd+xQDR2aNA3RngVM10O23/Lwk65Q==",
+      "deprecated": "starting from tsparticles v3 the packages are now moved to @tsparticles/package-name instead of tsparticles-package-name",
+      "license": "MIT",
+      "dependencies": {
+        "tsparticles-engine": "^2.12.0"
+      }
+    },
+    "node_modules/tsparticles-shape-image": {
+      "version": "2.12.0",
+      "resolved": "https://registry.npmjs.org/tsparticles-shape-image/-/tsparticles-shape-image-2.12.0.tgz",
+      "integrity": "sha512-iCkSdUVa40DxhkkYjYuYHr9MJGVw+QnQuN5UC+e/yBgJQY+1tQL8UH0+YU/h0GHTzh5Sm+y+g51gOFxHt1dj7Q==",
+      "deprecated": "starting from tsparticles v3 the packages are now moved to @tsparticles/package-name instead of tsparticles-package-name",
+      "license": "MIT",
+      "dependencies": {
+        "tsparticles-engine": "^2.12.0"
+      }
+    },
+    "node_modules/tsparticles-shape-line": {
+      "version": "2.12.0",
+      "resolved": "https://registry.npmjs.org/tsparticles-shape-line/-/tsparticles-shape-line-2.12.0.tgz",
+      "integrity": "sha512-RcpKmmpKlk+R8mM5wA2v64Lv1jvXtU4SrBDv3vbdRodKbKaWGGzymzav1Q0hYyDyUZgplEK/a5ZwrfrOwmgYGA==",
+      "deprecated": "starting from tsparticles v3 the packages are now moved to @tsparticles/package-name instead of tsparticles-package-name",
+      "license": "MIT",
+      "dependencies": {
+        "tsparticles-engine": "^2.12.0"
+      }
+    },
+    "node_modules/tsparticles-shape-polygon": {
+      "version": "2.12.0",
+      "resolved": "https://registry.npmjs.org/tsparticles-shape-polygon/-/tsparticles-shape-polygon-2.12.0.tgz",
+      "integrity": "sha512-5YEy7HVMt1Obxd/jnlsjajchAlYMr9eRZWN+lSjcFSH6Ibra7h59YuJVnwxOxAobpijGxsNiBX0PuGQnB47pmA==",
+      "deprecated": "starting from tsparticles v3 the packages are now moved to @tsparticles/package-name instead of tsparticles-package-name",
+      "license": "MIT",
+      "dependencies": {
+        "tsparticles-engine": "^2.12.0"
+      }
+    },
+    "node_modules/tsparticles-shape-square": {
+      "version": "2.12.0",
+      "resolved": "https://registry.npmjs.org/tsparticles-shape-square/-/tsparticles-shape-square-2.12.0.tgz",
+      "integrity": "sha512-33vfajHqmlODKaUzyPI/aVhnAOT09V7nfEPNl8DD0cfiNikEuPkbFqgJezJuE55ebtVo7BZPDA9o7GYbWxQNuw==",
+      "deprecated": "starting from tsparticles v3 the packages are now moved to @tsparticles/package-name instead of tsparticles-package-name",
+      "license": "MIT",
+      "dependencies": {
+        "tsparticles-engine": "^2.12.0"
+      }
+    },
+    "node_modules/tsparticles-shape-star": {
+      "version": "2.12.0",
+      "resolved": "https://registry.npmjs.org/tsparticles-shape-star/-/tsparticles-shape-star-2.12.0.tgz",
+      "integrity": "sha512-4sfG/BBqm2qBnPLASl2L5aBfCx86cmZLXeh49Un+TIR1F5Qh4XUFsahgVOG0vkZQa+rOsZPEH04xY5feWmj90g==",
+      "deprecated": "starting from tsparticles v3 the packages are now moved to @tsparticles/package-name instead of tsparticles-package-name",
+      "license": "MIT",
+      "dependencies": {
+        "tsparticles-engine": "^2.12.0"
+      }
+    },
+    "node_modules/tsparticles-shape-text": {
+      "version": "2.12.0",
+      "resolved": "https://registry.npmjs.org/tsparticles-shape-text/-/tsparticles-shape-text-2.12.0.tgz",
+      "integrity": "sha512-v2/FCA+hyTbDqp2ymFOe97h/NFb2eezECMrdirHWew3E3qlvj9S/xBibjbpZva2gnXcasBwxn0+LxKbgGdP0rA==",
+      "deprecated": "starting from tsparticles v3 the packages are now moved to @tsparticles/package-name instead of tsparticles-package-name",
+      "license": "MIT",
+      "dependencies": {
+        "tsparticles-engine": "^2.12.0"
+      }
+    },
+    "node_modules/tsparticles-slim": {
+      "version": "2.12.0",
+      "resolved": "https://registry.npmjs.org/tsparticles-slim/-/tsparticles-slim-2.12.0.tgz",
+      "integrity": "sha512-27w9aGAAAPKHvP4LHzWFpyqu7wKyulayyaZ/L6Tuuejy4KP4BBEB4rY5GG91yvAPsLtr6rwWAn3yS+uxnBDpkA==",
+      "deprecated": "starting from tsparticles v3 the packages are now moved to @tsparticles/package-name instead of tsparticles-package-name",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/matteobruni"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/tsparticles"
+        },
+        {
+          "type": "buymeacoffee",
+          "url": "https://www.buymeacoffee.com/matteobruni"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "tsparticles-basic": "^2.12.0",
+        "tsparticles-engine": "^2.12.0",
+        "tsparticles-interaction-external-attract": "^2.12.0",
+        "tsparticles-interaction-external-bounce": "^2.12.0",
+        "tsparticles-interaction-external-bubble": "^2.12.0",
+        "tsparticles-interaction-external-connect": "^2.12.0",
+        "tsparticles-interaction-external-grab": "^2.12.0",
+        "tsparticles-interaction-external-pause": "^2.12.0",
+        "tsparticles-interaction-external-push": "^2.12.0",
+        "tsparticles-interaction-external-remove": "^2.12.0",
+        "tsparticles-interaction-external-repulse": "^2.12.0",
+        "tsparticles-interaction-external-slow": "^2.12.0",
+        "tsparticles-interaction-particles-attract": "^2.12.0",
+        "tsparticles-interaction-particles-collisions": "^2.12.0",
+        "tsparticles-interaction-particles-links": "^2.12.0",
+        "tsparticles-move-base": "^2.12.0",
+        "tsparticles-move-parallax": "^2.12.0",
+        "tsparticles-particles.js": "^2.12.0",
+        "tsparticles-plugin-easing-quad": "^2.12.0",
+        "tsparticles-shape-circle": "^2.12.0",
+        "tsparticles-shape-image": "^2.12.0",
+        "tsparticles-shape-line": "^2.12.0",
+        "tsparticles-shape-polygon": "^2.12.0",
+        "tsparticles-shape-square": "^2.12.0",
+        "tsparticles-shape-star": "^2.12.0",
+        "tsparticles-shape-text": "^2.12.0",
+        "tsparticles-updater-color": "^2.12.0",
+        "tsparticles-updater-life": "^2.12.0",
+        "tsparticles-updater-opacity": "^2.12.0",
+        "tsparticles-updater-out-modes": "^2.12.0",
+        "tsparticles-updater-rotate": "^2.12.0",
+        "tsparticles-updater-size": "^2.12.0",
+        "tsparticles-updater-stroke-color": "^2.12.0"
+      }
+    },
+    "node_modules/tsparticles-updater-color": {
+      "version": "2.12.0",
+      "resolved": "https://registry.npmjs.org/tsparticles-updater-color/-/tsparticles-updater-color-2.12.0.tgz",
+      "integrity": "sha512-KcG3a8zd0f8CTiOrylXGChBrjhKcchvDJjx9sp5qpwQK61JlNojNCU35xoaSk2eEHeOvFjh0o3CXWUmYPUcBTQ==",
+      "deprecated": "starting from tsparticles v3 the packages are now moved to @tsparticles/package-name instead of tsparticles-package-name",
+      "license": "MIT",
+      "dependencies": {
+        "tsparticles-engine": "^2.12.0"
+      }
+    },
+    "node_modules/tsparticles-updater-destroy": {
+      "version": "2.12.0",
+      "resolved": "https://registry.npmjs.org/tsparticles-updater-destroy/-/tsparticles-updater-destroy-2.12.0.tgz",
+      "integrity": "sha512-6NN3dJhxACvzbIGL4dADbYQSZJmdHfwjujj1uvnxdMbb2x8C/AZzGxiN33smo4jkrZ5VLEWZWCJPJ8aOKjQ2Sg==",
+      "deprecated": "starting from tsparticles v3 the packages are now moved to @tsparticles/package-name instead of tsparticles-package-name",
+      "license": "MIT",
+      "dependencies": {
+        "tsparticles-engine": "^2.12.0"
+      }
+    },
+    "node_modules/tsparticles-updater-life": {
+      "version": "2.12.0",
+      "resolved": "https://registry.npmjs.org/tsparticles-updater-life/-/tsparticles-updater-life-2.12.0.tgz",
+      "integrity": "sha512-J7RWGHAZkowBHpcLpmjKsxwnZZJ94oGEL2w+wvW1/+ZLmAiFFF6UgU0rHMC5CbHJT4IPx9cbkYMEHsBkcRJ0Bw==",
+      "deprecated": "starting from tsparticles v3 the packages are now moved to @tsparticles/package-name instead of tsparticles-package-name",
+      "license": "MIT",
+      "dependencies": {
+        "tsparticles-engine": "^2.12.0"
+      }
+    },
+    "node_modules/tsparticles-updater-opacity": {
+      "version": "2.12.0",
+      "resolved": "https://registry.npmjs.org/tsparticles-updater-opacity/-/tsparticles-updater-opacity-2.12.0.tgz",
+      "integrity": "sha512-YUjMsgHdaYi4HN89LLogboYcCi1o9VGo21upoqxq19yRy0hRCtx2NhH22iHF/i5WrX6jqshN0iuiiNefC53CsA==",
+      "deprecated": "starting from tsparticles v3 the packages are now moved to @tsparticles/package-name instead of tsparticles-package-name",
+      "license": "MIT",
+      "dependencies": {
+        "tsparticles-engine": "^2.12.0"
+      }
+    },
+    "node_modules/tsparticles-updater-out-modes": {
+      "version": "2.12.0",
+      "resolved": "https://registry.npmjs.org/tsparticles-updater-out-modes/-/tsparticles-updater-out-modes-2.12.0.tgz",
+      "integrity": "sha512-owBp4Gk0JNlSrmp12XVEeBroDhLZU+Uq3szbWlHGSfcR88W4c/0bt0FiH5bHUqORIkw+m8O56hCjbqwj69kpOQ==",
+      "deprecated": "starting from tsparticles v3 the packages are now moved to @tsparticles/package-name instead of tsparticles-package-name",
+      "license": "MIT",
+      "dependencies": {
+        "tsparticles-engine": "^2.12.0"
+      }
+    },
+    "node_modules/tsparticles-updater-roll": {
+      "version": "2.12.0",
+      "resolved": "https://registry.npmjs.org/tsparticles-updater-roll/-/tsparticles-updater-roll-2.12.0.tgz",
+      "integrity": "sha512-dxoxY5jP4C9x15BxlUv5/Q8OjUPBiE09ToXRyBxea9aEJ7/iMw6odvi1HuT0H1vTIfV7o1MYawjeCbMycvODKQ==",
+      "deprecated": "starting from tsparticles v3 the packages are now moved to @tsparticles/package-name instead of tsparticles-package-name",
+      "license": "MIT",
+      "dependencies": {
+        "tsparticles-engine": "^2.12.0"
+      }
+    },
+    "node_modules/tsparticles-updater-rotate": {
+      "version": "2.12.0",
+      "resolved": "https://registry.npmjs.org/tsparticles-updater-rotate/-/tsparticles-updater-rotate-2.12.0.tgz",
+      "integrity": "sha512-waOFlGFmEZOzsQg4C4VSejNVXGf4dMf3fsnQrEROASGf1FCd8B6WcZau7JtXSTFw0OUGuk8UGz36ETWN72DkCw==",
+      "deprecated": "starting from tsparticles v3 the packages are now moved to @tsparticles/package-name instead of tsparticles-package-name",
+      "license": "MIT",
+      "dependencies": {
+        "tsparticles-engine": "^2.12.0"
+      }
+    },
+    "node_modules/tsparticles-updater-size": {
+      "version": "2.12.0",
+      "resolved": "https://registry.npmjs.org/tsparticles-updater-size/-/tsparticles-updater-size-2.12.0.tgz",
+      "integrity": "sha512-B0yRdEDd/qZXCGDL/ussHfx5YJ9UhTqNvmS5X2rR2hiZhBAE2fmsXLeWkdtF2QusjPeEqFDxrkGiLOsh6poqRA==",
+      "deprecated": "starting from tsparticles v3 the packages are now moved to @tsparticles/package-name instead of tsparticles-package-name",
+      "license": "MIT",
+      "dependencies": {
+        "tsparticles-engine": "^2.12.0"
+      }
+    },
+    "node_modules/tsparticles-updater-stroke-color": {
+      "version": "2.12.0",
+      "resolved": "https://registry.npmjs.org/tsparticles-updater-stroke-color/-/tsparticles-updater-stroke-color-2.12.0.tgz",
+      "integrity": "sha512-MPou1ZDxsuVq6SN1fbX+aI5yrs6FyP2iPCqqttpNbWyL+R6fik1rL0ab/x02B57liDXqGKYomIbBQVP3zUTW1A==",
+      "deprecated": "starting from tsparticles v3 the packages are now moved to @tsparticles/package-name instead of tsparticles-package-name",
+      "license": "MIT",
+      "dependencies": {
+        "tsparticles-engine": "^2.12.0"
+      }
+    },
+    "node_modules/tsparticles-updater-tilt": {
+      "version": "2.12.0",
+      "resolved": "https://registry.npmjs.org/tsparticles-updater-tilt/-/tsparticles-updater-tilt-2.12.0.tgz",
+      "integrity": "sha512-HDEFLXazE+Zw+kkKKAiv0Fs9D9sRP61DoCR6jZ36ipea6OBgY7V1Tifz2TSR1zoQkk57ER9+EOQbkSQO+YIPGQ==",
+      "deprecated": "starting from tsparticles v3 the packages are now moved to @tsparticles/package-name instead of tsparticles-package-name",
+      "license": "MIT",
+      "dependencies": {
+        "tsparticles-engine": "^2.12.0"
+      }
+    },
+    "node_modules/tsparticles-updater-twinkle": {
+      "version": "2.12.0",
+      "resolved": "https://registry.npmjs.org/tsparticles-updater-twinkle/-/tsparticles-updater-twinkle-2.12.0.tgz",
+      "integrity": "sha512-JhK/DO4kTx7IFwMBP2EQY9hBaVVvFnGBvX21SQWcjkymmN1hZ+NdcgUtR9jr4jUiiSNdSl7INaBuGloVjWvOgA==",
+      "deprecated": "starting from tsparticles v3 the packages are now moved to @tsparticles/package-name instead of tsparticles-package-name",
+      "license": "MIT",
+      "dependencies": {
+        "tsparticles-engine": "^2.12.0"
+      }
+    },
+    "node_modules/tsparticles-updater-wobble": {
+      "version": "2.12.0",
+      "resolved": "https://registry.npmjs.org/tsparticles-updater-wobble/-/tsparticles-updater-wobble-2.12.0.tgz",
+      "integrity": "sha512-85FIRl95ipD3jfIsQdDzcUC5PRMWIrCYqBq69nIy9P8rsNzygn+JK2n+P1VQZowWsZvk0mYjqb9OVQB21Lhf6Q==",
+      "deprecated": "starting from tsparticles v3 the packages are now moved to @tsparticles/package-name instead of tsparticles-package-name",
+      "license": "MIT",
+      "dependencies": {
+        "tsparticles-engine": "^2.12.0"
+      }
     },
     "node_modules/tunnel-agent": {
       "version": "0.6.0",

--- a/package.json
+++ b/package.json
@@ -40,7 +40,10 @@
     "socket.io-client": "^4.8.1",
     "three": "^0.178.0",
     "tone": "^15.1.22",
-    "zustand": "^5.0.6"
+    "zustand": "^5.0.6",
+    "react-tsparticles": "^2.12.2",
+    "tsparticles": "^2.12.0",
+    "tsparticles-engine": "^2.12.0"
   },
   "devDependencies": {
     "@tailwindcss/postcss": "^4.1.11",

--- a/src/components/StartOverlay.tsx
+++ b/src/components/StartOverlay.tsx
@@ -1,0 +1,69 @@
+"use client";
+import React, { useState, useCallback } from "react";
+import { motion, AnimatePresence } from "framer-motion";
+import Particles from "react-tsparticles";
+import type { Engine } from "tsparticles-engine";
+import { loadFull } from "tsparticles";
+
+interface StartOverlayProps {
+  onFinish: () => void;
+}
+
+export default function StartOverlay({ onFinish }: StartOverlayProps) {
+  const [exiting, setExiting] = useState(false);
+
+  const particlesInit = useCallback(async (engine: Engine) => {
+    await loadFull(engine);
+  }, []);
+
+  const particlesOptions = {
+    background: { color: { value: "transparent" } },
+    fullScreen: { enable: false },
+    fpsLimit: 60,
+    particles: {
+      number: { value: 60 },
+      color: { value: "#ffffff" },
+      size: { value: { min: 1, max: 3 } },
+      move: { enable: true, speed: 1 },
+      opacity: { value: 0.5 },
+      links: { enable: true, color: "#ffffff", opacity: 0.2, distance: 120 },
+    },
+  };
+
+  return (
+    <AnimatePresence onExitComplete={onFinish}>
+      {!exiting && (
+        <motion.div
+          key="overlay"
+          className="fixed inset-0 z-50 flex items-center justify-center text-white select-none"
+          style={{
+            background:
+              "radial-gradient(circle at center, rgba(0,0,0,0.95), #000000 80%)",
+          }}
+          initial={{ opacity: 1 }}
+          animate={{ opacity: 1 }}
+          exit={{ opacity: 0 }}
+          transition={{ duration: 1 }}
+          onClick={() => setExiting(true)}
+        >
+          <Particles
+            id="start-particles"
+            init={particlesInit}
+            options={particlesOptions}
+            className="absolute inset-0"
+          />
+          <motion.p
+            className="z-10 text-xl md:text-3xl font-semibold"
+            initial={{ opacity: 1 }}
+            animate={{
+              y: [0, -20, 0],
+              transition: { repeat: Infinity, duration: 6, ease: "easeInOut" },
+            }}
+          >
+            Let’s begin your sonic voyage…
+          </motion.p>
+        </motion.div>
+      )}
+    </AnimatePresence>
+  );
+}


### PR DESCRIPTION
## Summary
- implement fluid `StartOverlay` with react-tsparticles and framer-motion
- load WebGL scene and audio only after user gesture
- show overlay in `app/page.tsx` and lazy load CanvasScene
- add `react-tsparticles` dependency

## Testing
- `npx tsc --noEmit`
- `npm run lint`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68670322fee483269976119e29ca50ce