### PR TITLE
Add hydration safety docs and interaction gate

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -246,3 +246,4 @@ Task: CI/CD & Build Validation
 - Audit React hook usage for hydration safety (no conditional hooks or SSR-incompatible patterns)
 - Guarantee compatibility with both `npm run dev` and `npm run build`
 - Wrap all browser-dependent components with dynamic import or `"use client"` guard
+- Delay Three.js renderer and other side-effects until a user gesture dismisses `StartOverlay`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,5 +38,6 @@
 - AR & VR support via WebXR buttons (SpaceCanvas XR)
 - Real-time multiplayer through WebRTC signaling (AirJam Sessions)
 - Magenta.js integration for AI generated melodies (Magic Melody)
+- Hydration safety guide and `InteractionGate` component template
 
 

--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ Spawn, select and sculpt floating shapes that generate notes, chords, beats or l
 - **Installable PWA** — add to home screen for offline access.
 - **Service Worker Caching** — basic offline support via `public/sw.js`.
 - **Startup Performance Selector** — choose Eco/Balanced/Pro GPU mode.
+- **Hydration Safe Start** — WebGL and audio wait for a click via `StartOverlay` ([guide](docs/hydration-safety.md)).
 - **Audio-reactive Shaders** — shapes pulse and ripple in sync with FFT levels.
 - **Responsive Canvas** — camera and renderer resize with the window.
 - **Global Audio Engine**  
@@ -177,6 +178,11 @@ If Docker logs show `No swap limit support`, your host kernel does not enable
 swap accounting. You can enable it via your Docker daemon settings on newer
 kernels. Older distributions may not support this feature; the warning can be
 ignored in that case.
+
+### Hydration Errors
+If you see React hydration warnings on first load, make sure audio and WebGL
+setup only run after the `StartOverlay` is dismissed. See
+[`docs/hydration-safety.md`](docs/hydration-safety.md) for details.
 
 ---
 

--- a/docs/hydration-safety.md
+++ b/docs/hydration-safety.md
@@ -1,0 +1,13 @@
+# Hydration Safety Guide
+
+A prior bug caused React hydration errors because Tone.js and Three.js initialized during server-side render. The DOM generated on the server did not match what the client produced, triggering the infamous React error #185.
+
+## Prevention Checklist
+
+1. Wrap any browser-dependent logic (WebGLRenderer, AudioContext, media playback) behind a user gesture. The `StartOverlay` component in `app/page.tsx` is the reference implementation.
+2. Use dynamic imports with `{ ssr: false }` for client-only components.
+3. Keep procedural randomness and DOM modifications out of initial render on the server.
+4. Ensure all components with hooks include the `"use client"` directive.
+5. Delay creation of AudioContexts until `startAudio()` is invoked by a click or tap.
+
+Following these steps keeps the server-rendered HTML in sync with the client and prevents hydration mismatches.

--- a/src/components/InteractionGate.tsx
+++ b/src/components/InteractionGate.tsx
@@ -1,0 +1,26 @@
+"use client";
+import React from "react";
+
+interface InteractionGateProps {
+  started: boolean;
+  onStart: () => void;
+  children: React.ReactNode;
+}
+
+/**
+ * Generic overlay to defer interactive features until the user clicks.
+ * Prevents hydration mismatch by ensuring audio and WebGL start client-side.
+ */
+export default function InteractionGate({ started, onStart, children }: InteractionGateProps) {
+  if (!started) {
+    return (
+      <div
+        className="fixed inset-0 z-50 flex items-center justify-center bg-black/90 text-white cursor-pointer"
+        onClick={onStart}
+      >
+        Tap to start
+      </div>
+    );
+  }
+  return <>{children}</>;
+}


### PR DESCRIPTION
## Summary
- document hydration issue prevention steps
- add a minimal `InteractionGate` component for gating WebGL and AudioContext
- note hydration instructions in README and AGENTS
- update changelog

## Testing
- `npx tsc --noEmit`
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6869fbc7e23883268b9b9fb2bbbac3d9