### PR TITLE
Fix lint warning

### DIFF
--- a/src/components/MagentaMusicEngine.tsx
+++ b/src/components/MagentaMusicEngine.tsx
@@ -251,7 +251,7 @@ const MagentaMusicEngine: React.FC<MagentaMusicEngineProps> = ({
     } finally {
       setIsLoading(false)
     }
-  }, [models, config, audioData, onSequenceGenerated, generateEnhancedAlgorithmicSequence, generateAlgorithmicSequence, isLoading]) // Added all dependencies
+  }, [models, audioData, onSequenceGenerated, generateEnhancedAlgorithmicSequence, generateAlgorithmicSequence, isLoading])
 
   // Auto-generate based on audio energy
   useEffect(() => {


### PR DESCRIPTION
## Summary
- remove unused `config` dependency in `MagentaMusicEngine`

## Testing
- `npx tsc --noEmit`
- `npm run lint`
- `npm run build`
- `npx next start` *(terminated after startup)*
- `npm run test:smoke`


------
https://chatgpt.com/codex/tasks/task_e_68734a24c82c8326bcad64fb0e8b2aaa