### PR TITLE
fix: deployment workflow improvements

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -59,7 +59,7 @@ jobs:
 
       - name: 📦 Install dependencies
         if: steps.changes.outputs.src == 'true'
-        run: npm ci --legacy-peer-deps
+        run: npm ci
 
       - name: 🔎 Type-check, lint & build
         if: steps.changes.outputs.src == 'true'
@@ -83,7 +83,15 @@ jobs:
             --cache-to=type=local,dest=./.buildcache,mode=max \
             -t interactive-music-web .
           echo "Stopping and removing old container if exists"
+          docker stop interactive-music-web || true
           docker rm -f interactive-music-web || true
+          
+          # Wait for port to be released
+          sleep 2
+          
+          # Kill any processes using port 31415 as fallback
+          sudo lsof -ti:31415 | xargs -r sudo kill -9 || true
+          
           echo "Starting new container from built image"
           docker run -d --name interactive-music-web \
             --restart unless-stopped \


### PR DESCRIPTION
## Summary
- Remove `--legacy-peer-deps` flag from npm ci (no longer needed after dependency modernization)
- Enhance Docker container cleanup to prevent port 31415 conflicts
- Add proper container stop sequence before removal
- Add port release timing and fallback cleanup with lsof/kill

## Test plan
- [x] Verify deployment workflow runs without legacy peer deps
- [x] Test enhanced Docker container cleanup prevents port conflicts
- [x] Confirm proper container lifecycle management

🤖 Generated with [Claude Code](https://claude.ai/code)