### PR TITLE
Fix build deploy pipeline

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -11,9 +11,7 @@ on:
 
 jobs:
   build-and-deploy:
-    runs-on:
-      - self-hosted
-      - interactive-music-3d
+    runs-on: ubuntu-latest
 
     env:
       NEXT_TELEMETRY_DISABLED: 1


### PR DESCRIPTION
## Summary
- use GitHub hosted runners for deploy to fix failing build job

## Testing
- `npx tsc --noEmit`
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6885902abd508326a4245e21b81e86ac