### PR TITLE
Fix deploy workflow cleanup

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -46,12 +46,8 @@ jobs:
           # Clean up any orphaned containers with our name
           docker ps -a --filter "name=interactive-music-web" --format "{{.ID}}" | xargs -r docker rm -f 2>/dev/null || echo "No orphaned containers"
           
-          # Clean up Docker system to release port bindings
-          echo "Cleaning up Docker system..."
-          docker system prune -f 2>/dev/null || true
-          
-          # Wait longer for Docker internal cleanup
-          sleep 5
+          # Short wait to ensure port is released
+          sleep 2
           echo "✅ Early cleanup completed"
 
       - name: 🔄 Restore Next.js cache


### PR DESCRIPTION
## Summary
- only remove the `interactive-music-web` container during early cleanup

## Testing
- `npm ci`
- `npx tsc --noEmit`
- `npm run lint`
- `npm run build`
- `npx next start`

------
https://chatgpt.com/codex/tasks/task_e_6886d9577bd48326b81f0f06ae248a85