### PR TITLE
Fix port docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,7 +125,7 @@
 
    ```bash
    npm run dev
-   # → http://localhost:3000
+   # → http://localhost:$WEB_PORT (default 3000)
    # Hot reload enabled with TypeScript checking
    ```
 
@@ -134,7 +134,7 @@
    ```bash
    npm run build
    npm run start
-   # → http://localhost:3000 (production mode)
+   # → http://localhost:$WEB_PORT (default 3000)
    ```
 
 3. **Testing & validation**
@@ -299,8 +299,10 @@ CMD ["node", "server.js"]
 services:
   oscillo:
     build: .
+    # Map desired host port to container's internal port 3000
+    # Set WEB_PORT to override (e.g. WEB_PORT=32415 docker-compose up)
     ports:
-      - "3000:3000"
+      - "${WEB_PORT:-3000}:3000"
     environment:
       - NODE_ENV=production
       - LOG_DIR=/app/logs
@@ -567,16 +569,16 @@ npm run profile
 
 ```bash
 # Health check endpoint
-curl http://localhost:3000/api/health
+curl http://localhost:$WEB_PORT/api/health
 
 # WebGL capabilities
-curl http://localhost:3000/api/webgl-info
+curl http://localhost:$WEB_PORT/api/webgl-info
 
 # Audio system status
-curl http://localhost:3000/api/audio-status
+curl http://localhost:$WEB_PORT/api/audio-status
 
 # Performance metrics
-curl http://localhost:3000/api/metrics
+curl http://localhost:$WEB_PORT/api/metrics
 ```
 
 ---

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,10 +4,11 @@ services:
     build: .
     image: your-dockerhub-username/interactive-music-3d:latest
     ports:
-      - "3000:3000"
+      - "${WEB_PORT:-3000}:3000"
     environment:
       - NODE_ENV=production
       - LOG_DIR=/app/logs
+      - PORT=${WEB_PORT:-3000}
     volumes:
       - /mnt/user/appdata/interactive-music-3d/logs:/app/logs
       - /mnt/user/appdata/interactive-music-3d/uploads:/app/uploads

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -49,7 +49,7 @@ npm run start  # Now correctly uses NODE_ENV=production
 
 ## Test security headers locally
 
-curl -I http://localhost:3000
+curl -I http://localhost:${WEB_PORT:-3000}
 
 
 ## Should see headers
@@ -112,7 +112,7 @@ COPY --from=builder --chown=nextjs:nodejs /app/.next/static ./.next/static
 
 USER nextjs
 EXPOSE 3000
-ENV PORT 3000
+ENV PORT ${WEB_PORT:-3000}
 ENV HOSTNAME "0.0.0.0"
 
 CMD ["node", "server.js"]
@@ -130,7 +130,7 @@ services:
   interactive-music-3d:
     build: .
     ports:
-      * "3000:3000"
+      * "${WEB_PORT:-3000}:3000" # Override with WEB_PORT if needed
     environment:
       * NODE_ENV=production
       * LOG_DIR=/app/logs
@@ -362,7 +362,7 @@ docker rm interactive-music-3d || true
 docker run -d \
   --name interactive-music-3d \
   --restart unless-stopped \
-  -p 3000:3000 \
+  -p ${WEB_PORT:-3000}:3000 \
   -e NODE_ENV=production \
   -e LOG_DIR=/app/logs \
   -v $(pwd)/logs:/app/logs \
@@ -391,7 +391,7 @@ docker rm interactive-music-3d
 
 docker run -d --name interactive-music-3d \
   --restart unless-stopped \
-  -p 3000:3000 \
+  -p ${WEB_PORT:-3000}:3000 \
   interactive-music-3d:previous-tag
 
 


### PR DESCRIPTION
## Summary
- clarify that the app uses port 3000 by default
- show how to override the port via `WEB_PORT`

## Testing
- `npx tsc --noEmit`
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6886e41f970c8326a22a1311281293d7