### PR TITLE
Document HOST_PORT override for Docker

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -113,11 +113,11 @@ jobs:
           
           # Fallback to high port if all low ports fail
           if [ -z "$ALTERNATIVE_PORT" ]; then
-            echo "Using fallback high port 32415"
-            echo "ALTERNATIVE_PORT=32415" >> $GITHUB_ENV
+            echo "Using fallback high port 31415"
+            echo "ALTERNATIVE_PORT=31415" >> $GITHUB_ENV
           fi
-          
-          echo "Will use port: ${ALTERNATIVE_PORT:-32415}"
+
+          echo "Will use port: ${ALTERNATIVE_PORT:-31415}"
 
       - name: 🔨 Build Docker image
         if: steps.changes.outputs.src == 'true'

--- a/README.md
+++ b/README.md
@@ -300,7 +300,7 @@ services:
   oscillo:
     build: .
     ports:
-      - "3000:3000"
+      - "${HOST_PORT:-31415}:3000"  # Change HOST_PORT to expose a different host port
     environment:
       - NODE_ENV=production
       - LOG_DIR=/app/logs
@@ -312,8 +312,12 @@ services:
       interval: 30s
       timeout: 10s
       retries: 3
-    restart: unless-stopped
+  restart: unless-stopped
 ```
+
+Set the `HOST_PORT` environment variable when running `docker compose up` to
+expose a different host port (for example `HOST_PORT=31415`). The application
+inside the container still listens on port 3000.
 
 ### **GitHub Actions CI/CD**
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,8 +3,9 @@ services:
   interactive-music-3d:
     build: .
     image: your-dockerhub-username/interactive-music-3d:latest
+    # Allow custom host port via HOST_PORT env variable
     ports:
-      - "3000:3000"
+      - "${HOST_PORT:-31415}:3000"
     environment:
       - NODE_ENV=production
       - LOG_DIR=/app/logs

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -130,7 +130,7 @@ services:
   interactive-music-3d:
     build: .
     ports:
-      * "3000:3000"
+      * "${HOST_PORT:-31415}:3000" # Set HOST_PORT to expose a different port on the host
     environment:
       * NODE_ENV=production
       * LOG_DIR=/app/logs
@@ -138,6 +138,12 @@ services:
       * ./logs:/app/logs
       * ./uploads:/app/uploads
     restart: unless-stopped
+``` 
+
+You can override `HOST_PORT` when running `docker compose up` to bind a
+different external port, e.g. `HOST_PORT=31415 docker compose up -d`.
+
+```yaml
     healthcheck:
       test: ["CMD", "curl", "-f", "http://localhost:3000/api/health"]
       interval: 30s


### PR DESCRIPTION
## Summary
- allow docker-compose to override host port using `HOST_PORT`
- document port configuration in README
- add note about `HOST_PORT` in deployment docs
- set default external port to 31415

## Testing
- `npx tsc --noEmit`
- `npm run lint`
- `npm run build`
- `npm run start` (manual start)


------
https://chatgpt.com/codex/tasks/task_e_6886e41f970c8326a22a1311281293d7