### PR TITLE
Add build artifact upload to CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,6 +19,14 @@ jobs:
       - run: npx tsc --noEmit
       - run: npm run lint
       - run: npm run build
+      - name: Upload build artifacts
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: build-files
+          path: .next
+          if-no-files-found: error
+          retention-days: 1
       - name: Install Playwright browsers and system dependencies
         run: npx playwright install --with-deps
       - name: Run Playwright tests


### PR DESCRIPTION
## Summary
- upload build artifacts in quick-checks

## Testing
- `npx tsc --noEmit`
- `npm run lint`
- `npm run build`
- `npm start`

------
https://chatgpt.com/codex/tasks/task_e_6887d188dcf48326b9f348ecfee69615