### PR TITLE
Update health check URL in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -51,9 +51,9 @@ COPY --from=builder /app/public ./public
 COPY --from=builder /app/.next ./.next
 COPY --from=builder /app/node_modules ./node_modules
 
-# Health check - use server IP instead of localhost
+# Health check
 HEALTHCHECK --interval=30s --timeout=10s --start-period=5s --retries=3 \
-    CMD curl -f http://192.168.4.225:32415/api/health || exit 1
+    CMD curl -f http://localhost:3000/api/health || exit 1
 
 EXPOSE 3000
 


### PR DESCRIPTION
## Summary
- update Dockerfile health check to use localhost

## Testing
- `npx tsc --noEmit`
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6887d2e3bd1c83268fd92f7a03bf3105