### PR TITLE
feat(native): add macOS app pipeline and update channel

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,6 +1,5 @@
 blank_issues_enabled: false
 contact_links:
-  - name: Questions & Discussion
-    url: https://github.com/zachyzissou/INTERACTIVE-MUSIC-3D/discussions
-    about: Please use GitHub Discussions for Q&A and ideas.
-
+  - name: Repository
+    url: https://github.com/zachyzissou/Oscillo
+    about: Use issues for actionable bugs, features, native release work, and CI tasks.

--- a/.github/ISSUE_TEMPLATE/native_app_bug.yml
+++ b/.github/ISSUE_TEMPLATE/native_app_bug.yml
@@ -1,0 +1,59 @@
+name: Native macOS bug
+description: Report a reproducible issue in the Swift/Metal macOS app
+title: "native: "
+labels: ["native", "bug"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Use this for issues in `native/dist/Oscillo.app`, `native/Sources`, or the native CI/release lane.
+  - type: input
+    id: version
+    attributes:
+      label: App version / build
+      description: Use the app version, release tag, or commit SHA.
+      placeholder: "native-v0.1.0 / c326b43"
+    validations:
+      required: true
+  - type: dropdown
+    id: input_mode
+    attributes:
+      label: Input mode
+      options:
+        - Preview signal
+        - Microphone
+        - Update check
+        - Launch/build
+    validations:
+      required: true
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected behavior
+      description: What should have happened?
+    validations:
+      required: true
+  - type: textarea
+    id: actual
+    attributes:
+      label: Actual behavior
+      description: What happened instead?
+    validations:
+      required: true
+  - type: textarea
+    id: steps
+    attributes:
+      label: Reproduction steps
+      value: |
+        1.
+        2.
+        3.
+    validations:
+      required: true
+  - type: textarea
+    id: evidence
+    attributes:
+      label: Logs, screenshots, or video
+      description: Attach a screenshot/video or paste relevant terminal output.
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/native_release_task.yml
+++ b/.github/ISSUE_TEMPLATE/native_release_task.yml
@@ -1,0 +1,46 @@
+name: Native release / update task
+description: Track macOS release, update-channel, signing, or OTA work
+title: "native release: "
+labels: ["native", "release"]
+body:
+  - type: dropdown
+    id: lane
+    attributes:
+      label: Lane
+      options:
+        - GitHub Actions CI
+        - GitHub Release artifact
+        - In-app update check
+        - Sparkle OTA installer
+        - Code signing / notarization
+    validations:
+      required: true
+  - type: textarea
+    id: goal
+    attributes:
+      label: Goal
+      description: What outcome should this task produce?
+    validations:
+      required: true
+  - type: textarea
+    id: acceptance
+    attributes:
+      label: Acceptance criteria
+      value: |
+        - [ ]
+        - [ ]
+        - [ ]
+    validations:
+      required: true
+  - type: textarea
+    id: verification
+    attributes:
+      label: Verification commands
+      value: |
+        ```bash
+        cd native
+        swift test
+        ./Scripts/build-macos-app.sh
+        ```
+    validations:
+      required: false

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -4,6 +4,8 @@ Briefly describe what this PR changes.
 ## Type of change
 - [ ] Docs / README
 - [ ] CI / automation
+- [ ] Native macOS
+- [ ] Native release/update channel
 - [ ] Security baseline files
 - [ ] Other
 
@@ -12,6 +14,7 @@ Please include command outputs and checks run:
 - [ ] Lint:
 - [ ] Tests:
 - [ ] Build:
+- [ ] Native:
 - [ ] Security scan:
 
 ## Related issues
@@ -23,4 +26,5 @@ Closes/Fixes/Refs:
 - [ ] Issue template and PR template present
 - [ ] CODEOWNERS added/validated (public repos preferred)
 - [ ] CI files include this PR and pass locally
+- [ ] Native changes update `native/README.md` or `native/UPDATES.md` when behavior changes
 - [ ] Branch note added if default branch is `master` or custom

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,9 +6,39 @@ on:
   pull_request:
 
 jobs:
+  changes:
+    runs-on: ubuntu-latest
+    outputs:
+      web: ${{ steps.filter.outputs.web }}
+    steps:
+      - uses: actions/checkout@v4
+      - id: filter
+        uses: dorny/paths-filter@v3
+        with:
+          filters: |
+            web:
+              - 'app/**'
+              - 'src/**'
+              - 'server/**'
+              - 'public/**'
+              - 'tests/**'
+              - 'cypress/**'
+              - 'tools/**'
+              - 'scripts/**'
+              - 'package.json'
+              - 'package-lock.json'
+              - 'next.config*.js'
+              - 'tsconfig.json'
+              - 'tailwind.config.ts'
+              - 'postcss.config.js'
+              - 'eslint.config.js'
+              - 'Dockerfile'
+
   # Quick checks for all PRs and main branch - under 10 minutes
   quick-checks:
     runs-on: ubuntu-latest
+    needs: changes
+    if: needs.changes.outputs.web == 'true'
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
@@ -38,6 +68,8 @@ jobs:
 
   security-audit:
     runs-on: ubuntu-latest
+    needs: changes
+    if: needs.changes.outputs.web == 'true'
     env:
       SECURITY_AUDIT_LEVEL: ${{ vars.SECURITY_AUDIT_LEVEL }}
     steps:
@@ -75,8 +107,8 @@ jobs:
   # Full test suite - only runs on staging branch
   full-tests:
     runs-on: ubuntu-latest
-    if: github.ref == 'refs/heads/staging'
-    needs: quick-checks
+    if: needs.changes.outputs.web == 'true' && github.ref == 'refs/heads/staging'
+    needs: [changes, quick-checks]
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
@@ -131,8 +163,8 @@ jobs:
 
   visual-regression:
     runs-on: ubuntu-latest
-    needs: quick-checks
-    if: github.ref == 'refs/heads/main' || github.event_name == 'pull_request'
+    needs: [changes, quick-checks]
+    if: needs.changes.outputs.web == 'true' && (github.ref == 'refs/heads/main' || github.event_name == 'pull_request')
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
@@ -164,20 +196,27 @@ jobs:
 
   baseline-ci:
     runs-on: ubuntu-latest
-    needs: [quick-checks, visual-regression, security-audit, full-tests]
+    needs: [changes, quick-checks, visual-regression, security-audit, full-tests]
     if: always()
     steps:
       - name: Enforce baseline CI signal
         run: |
+          web="${{ needs.changes.outputs.web }}"
           quick="${{ needs.quick-checks.result }}"
           visual="${{ needs.visual-regression.result }}"
           security="${{ needs.security-audit.result }}"
           full="${{ needs.full-tests.result }}"
 
+          echo "web changes: ${web}"
           echo "quick-checks: ${quick}"
           echo "visual-regression: ${visual}"
           echo "security-audit: ${security}"
           echo "full-tests: ${full}"
+
+          if [ "${web}" != "true" ]; then
+            echo "No web runtime changes detected; web CI jobs intentionally skipped."
+            exit 0
+          fi
 
           if [ "${quick}" != "success" ]; then
             echo "quick-checks must pass."

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - id: filter
-        uses: dorny/paths-filter@v3
+        uses: dorny/paths-filter@6852f92c20ea7fd3b0c25de3b5112db3a98da050
         with:
           filters: |
             web:

--- a/.github/workflows/native-macos.yml
+++ b/.github/workflows/native-macos.yml
@@ -1,0 +1,62 @@
+name: Native macOS
+
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - 'native/**'
+      - '.github/workflows/native-macos.yml'
+  push:
+    branches: [main]
+    paths:
+      - 'native/**'
+      - '.github/workflows/native-macos.yml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  test-and-package:
+    name: Swift tests and macOS app bundle
+    runs-on: macos-26
+    timeout-minutes: 20
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Toolchain
+        run: |
+          xcodebuild -version
+          swift --version
+          xcrun --sdk macosx --show-sdk-version
+
+      - name: Swift tests
+        working-directory: native
+        run: swift test
+
+      - name: Build signed local app bundle
+        working-directory: native
+        run: ./Scripts/build-macos-app.sh
+
+      - name: Verify app signature
+        working-directory: native
+        run: codesign --verify --deep --strict dist/Oscillo.app
+
+      - name: Zip app artifact
+        working-directory: native
+        run: |
+          rm -f dist/Oscillo-macOS-ci.zip
+          ditto -c -k --keepParent dist/Oscillo.app dist/Oscillo-macOS-ci.zip
+          shasum -a 256 dist/Oscillo-macOS-ci.zip | tee dist/Oscillo-macOS-ci.zip.sha256
+
+      - name: Upload native app artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: Oscillo-macOS-ci
+          path: |
+            native/dist/Oscillo-macOS-ci.zip
+            native/dist/Oscillo-macOS-ci.zip.sha256
+          if-no-files-found: error
+          retention-days: 14

--- a/.github/workflows/native-release.yml
+++ b/.github/workflows/native-release.yml
@@ -26,9 +26,11 @@ jobs:
 
       - name: Resolve release metadata
         id: meta
+        env:
+          REQUESTED_TAG: ${{ inputs.tag }}
         run: |
-          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
-            tag="${{ inputs.tag }}"
+          if [ "${GITHUB_EVENT_NAME}" = "workflow_dispatch" ]; then
+            tag="${REQUESTED_TAG}"
           else
             tag="${GITHUB_REF_NAME}"
           fi

--- a/.github/workflows/native-release.yml
+++ b/.github/workflows/native-release.yml
@@ -1,0 +1,114 @@
+name: Native macOS Release
+
+on:
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: Native release tag, for example native-v0.1.0
+        required: true
+        type: string
+  push:
+    tags:
+      - 'native-v*'
+
+permissions:
+  contents: write
+
+jobs:
+  release:
+    name: Build and publish native macOS release
+    runs-on: macos-26
+    timeout-minutes: 25
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Resolve release metadata
+        id: meta
+        run: |
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            tag="${{ inputs.tag }}"
+          else
+            tag="${GITHUB_REF_NAME}"
+          fi
+
+          if ! printf '%s' "$tag" | grep -Eq '^native-v[0-9]+\.[0-9]+\.[0-9]+$'; then
+            echo "Native release tags must match native-vX.Y.Z" >&2
+            exit 64
+          fi
+
+          version="${tag#native-v}"
+          echo "tag=$tag" >> "$GITHUB_OUTPUT"
+          echo "version=$version" >> "$GITHUB_OUTPUT"
+
+      - name: Toolchain
+        run: |
+          xcodebuild -version
+          swift --version
+          xcrun --sdk macosx --show-sdk-version
+
+      - name: Test native package
+        working-directory: native
+        run: swift test
+
+      - name: Build app bundle
+        working-directory: native
+        run: ./Scripts/build-macos-app.sh
+
+      - name: Package release assets
+        working-directory: native
+        env:
+          TAG_NAME: ${{ steps.meta.outputs.tag }}
+          VERSION: ${{ steps.meta.outputs.version }}
+          REPOSITORY: ${{ github.repository }}
+        run: |
+          zip_name="Oscillo-macOS-${VERSION}.zip"
+          zip_path="dist/${zip_name}"
+          download_url="https://github.com/${REPOSITORY}/releases/download/${TAG_NAME}/${zip_name}"
+          release_url="https://github.com/${REPOSITORY}/releases/tag/${TAG_NAME}"
+
+          rm -f "$zip_path" "$zip_path.sha256" dist/oscillo-native-update.json
+          ditto -c -k --keepParent dist/Oscillo.app "$zip_path"
+          sha256="$(shasum -a 256 "$zip_path" | awk '{print $1}')"
+          printf '%s  %s\n' "$sha256" "$zip_name" > "$zip_path.sha256"
+
+          python3 Scripts/generate-update-manifest.py \
+            --version "$VERSION" \
+            --tag "$TAG_NAME" \
+            --download-url "$download_url" \
+            --release-url "$release_url" \
+            --sha256 "$sha256" \
+            --output dist/oscillo-native-update.json
+
+      - name: Create or update GitHub release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAG_NAME: ${{ steps.meta.outputs.tag }}
+          VERSION: ${{ steps.meta.outputs.version }}
+        run: |
+          notes_file="$(mktemp)"
+          {
+            echo "Native macOS build ${VERSION}"
+            echo
+            echo "Assets:"
+            echo "- Oscillo-macOS-${VERSION}.zip"
+            echo "- Oscillo-macOS-${VERSION}.zip.sha256"
+            echo "- oscillo-native-update.json"
+          } > "$notes_file"
+
+          if gh release view "$TAG_NAME" >/dev/null 2>&1; then
+            gh release upload "$TAG_NAME" \
+              "native/dist/Oscillo-macOS-${VERSION}.zip" \
+              "native/dist/Oscillo-macOS-${VERSION}.zip.sha256" \
+              "native/dist/oscillo-native-update.json" \
+              --clobber
+          else
+            gh release create "$TAG_NAME" \
+              "native/dist/Oscillo-macOS-${VERSION}.zip" \
+              "native/dist/Oscillo-macOS-${VERSION}.zip.sha256" \
+              "native/dist/oscillo-native-update.json" \
+              --target "$GITHUB_SHA" \
+              --title "Oscillo Native ${VERSION}" \
+              --notes-file "$notes_file"
+          fi

--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,8 @@ node_modules/
 package-lock.json
 .buildcache/*
 !.buildcache/.gitkeep
+native/.build/
+native/dist/
 tsconfig.tsbuildinfo
 
 # Test artifacts and build results

--- a/native/APPLE_TECH_MAP.md
+++ b/native/APPLE_TECH_MAP.md
@@ -11,7 +11,7 @@ Local toolchain checked:
 
 ## Direction
 
-Oscillo should become a native Swift app, not a WebView wrapper. The first build should keep the current web app intact and add a native lane under `native/` with shared `OscilloCore` logic, a macOS SwiftUI shell, and a Metal renderer. iOS should reuse the same core/audio/rendering contracts after the macOS slice is stable.
+Oscillo should become a native Swift app, not a WebView wrapper and not a strict Three.js port. The first build should keep the current web app intact and add a native lane under `native/` with shared `OscilloCore` logic, a macOS SwiftUI shell, and a Metal renderer. iOS should reuse the same core/audio/rendering contracts after the macOS slice is stable.
 
 All items below are Apple-provided platform frameworks or tools available with Xcode. A few capabilities still need OS/device support, user permissions, or entitlements before they can ship, such as microphone capture, SharePlay, Apple Intelligence availability, and iOS haptics.
 

--- a/native/APPLE_TECH_MAP.md
+++ b/native/APPLE_TECH_MAP.md
@@ -1,0 +1,90 @@
+# Oscillo Native Apple Tech Map
+
+Research date: 2026-04-25
+
+Local toolchain checked:
+
+- Xcode: `26.4.1`
+- macOS SDK: `26.4`
+- iPhoneOS SDK: `26.4`
+- Swift: `6.2.3`
+
+## Direction
+
+Oscillo should become a native Swift app, not a WebView wrapper. The first build should keep the current web app intact and add a native lane under `native/` with shared `OscilloCore` logic, a macOS SwiftUI shell, and a Metal renderer. iOS should reuse the same core/audio/rendering contracts after the macOS slice is stable.
+
+All items below are Apple-provided platform frameworks or tools available with Xcode. A few capabilities still need OS/device support, user permissions, or entitlements before they can ship, such as microphone capture, SharePlay, Apple Intelligence availability, and iOS haptics.
+
+## Apple Frameworks To Use
+
+| Area | Apple tech | Use in Oscillo | Adoption |
+| --- | --- | --- | --- |
+| App shell | SwiftUI, Swift concurrency, Observation | Cross-platform UI, state, settings, timeline-driven UI effects | Now |
+| Primary renderer | MetalKit, `MTKView`, Metal Shading Language | Audio-reactive tunnel, particles, morphing geometry, shader passes | Now |
+| New renderer backend | Metal 4 core API | More efficient command submission, command allocators, argument tables, newer barriers | Gate behind OS/GPU availability |
+| Shader compilation | Metal 4 compiler API, binary archives | Precompile shader variants and avoid runtime shader hitches | After shader library split |
+| Performance scaling | MetalFX spatial/temporal scaling, frame interpolation where available | Render lower-res heavy scenes, upscale to display, preserve visual richness on iPhone | After render targets exist |
+| GPU compute/ML | Metal Performance Shaders, MPSGraph, Core ML | Beat/structure analysis, generative controls, effect classifiers, model-backed visual selection | After audio feature pipeline is stable |
+| Audio input/synthesis | AVFAudio, AVAudioEngine, AVAudioSourceNode, AVAudioPlayerNode | Replace Tone.js/Web Audio; synth notes, capture microphone, route effect graph | Now |
+| Audio analysis | Accelerate/vDSP FFT and filters | RMS, spectral centroid, band energy, spectrogram textures | Now; replace initial Goertzel estimate with vDSP FFT |
+| Sound intelligence | Sound Analysis, Create ML, Core ML | Optional classifier for voice/music/noise/beat-event semantics | Later, on-device |
+| Spatial audio | AVAudioEnvironmentNode, PHASE, RealityKit spatial audio | 3D note sources and listener-aware mix | Later macOS/iOS; deeper for visionOS |
+| Haptics | Core Haptics | iPhone/iPad beat pulses, note taps, controller haptics | iOS phase |
+| Collaboration | Group Activities / SharePlay | Native shared jam sessions without a custom WebSocket-first UX | Later; entitlement-gated |
+| Assets | Model I/O, MetalKit texture/model loaders | Import procedural/GLTF/USDZ-inspired assets and generate mesh data | Later |
+| AI assistance | Foundation Models framework | On-device prompt-to-palette / prompt-to-scene presets where Apple Intelligence is available | Progressive enhancement |
+| Persistence | SwiftData / AppStorage / FileDocument | Local presets, exported scenes, user settings | After first native scene |
+| Automation | App Intents, Shortcuts | Start scene, export clip, switch palette, trigger jam actions | Later |
+
+## Renderer Plan
+
+Start with a normal MetalKit renderer because it is stable across current macOS/iOS targets and works in Swift Package form. Keep renderer responsibilities behind a narrow protocol so a Metal 4 backend can replace the command-submission layer without changing audio, state, or UI.
+
+Immediate renderer layers:
+
+- Full-screen shader pass for the tunnel/background.
+- GPU particle buffers for note systems.
+- Uniform buffer sourced from `OscilloCore.AudioFeatures`.
+- Quality profile that can lower particle count and render scale.
+
+Metal 4 should be introduced when the app has multiple passes or enough shader variants to justify the newer API surface. The docs explicitly describe Metal 4 as incrementally adoptable alongside existing Metal queues, so the project should avoid a hard rewrite when we add it.
+
+## Audio Plan
+
+Use `AVAudioEngine` as the native audio graph and `Accelerate/vDSP` for feature extraction. The current native slice uses a vDSP FFT analyzer that outputs:
+
+- RMS / volume
+- Bass, mid, treble energy
+- Peak frequency
+- Spectral centroid
+- Zero-crossing rate
+- Optional spectrogram texture for Metal
+
+For iOS, add `AVAudioSession` configuration and `NSMicrophoneUsageDescription`. For macOS app bundles, add the corresponding microphone usage string before relying on real input.
+
+## ML And Generative Features
+
+Keep ML optional and on-device-first:
+
+- Core ML for custom exported models and low-latency local inference.
+- Sound Analysis for built-in or custom sound classifiers over live audio streams.
+- Create ML for training small sound classifiers locally on Mac.
+- Foundation Models for prompt-driven palette/scene generation where Apple Intelligence is available.
+- MPSGraph or Metal 4 ML for GPU-timeline compute when the visual pipeline needs model-like operations near the renderer.
+
+## Source Links
+
+- Metal 4 overview: https://developer.apple.com/documentation/Metal/understanding-the-metal-4-core-api
+- Metal 4 triangle sample: https://developer.apple.com/documentation/metal/drawing-a-triangle-with-metal-4
+- MetalFX: https://developer.apple.com/documentation/metalfx/
+- Metal feature set tables: https://developer.apple.com/metal/capabilities/
+- vDSP: https://developer.apple.com/documentation/accelerate/vdsp
+- AVAudioEngine: https://developer.apple.com/documentation/avfaudio/avaudioengine
+- Sound Analysis stream classification: https://developer.apple.com/documentation/soundanalysis/classifying-sounds-in-an-audio-stream
+- Core ML overview: https://developer.apple.com/machine-learning/core-ml/
+- Foundation Models: https://developer.apple.com/documentation/FoundationModels
+- AVAudioEnvironmentNode: https://developer.apple.com/documentation/avfaudio/avaudioenvironmentnode
+- Core Haptics: https://developer.apple.com/documentation/corehaptics/
+- Model I/O: https://developer.apple.com/documentation/modelio
+- SharePlay activities: https://developer.apple.com/documentation/groupactivities/defining-your-apps-shareplay-activities
+- Metal shader validation: https://developer.apple.com/documentation/xcode/validating-your-apps-metal-shader-usage/

--- a/native/AppBundle/Info.plist
+++ b/native/AppBundle/Info.plist
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>en</string>
+	<key>CFBundleDisplayName</key>
+	<string>Oscillo</string>
+	<key>CFBundleExecutable</key>
+	<string>OscilloMac</string>
+	<key>CFBundleIdentifier</key>
+	<string>com.zachyzissou.oscillo.native.mac</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>Oscillo</string>
+	<key>CFBundlePackageType</key>
+	<string>APPL</string>
+	<key>CFBundleShortVersionString</key>
+	<string>0.1.0</string>
+	<key>CFBundleVersion</key>
+	<string>1</string>
+	<key>LSApplicationCategoryType</key>
+	<string>public.app-category.music</string>
+	<key>LSMinimumSystemVersion</key>
+	<string>14.0</string>
+	<key>NSHighResolutionCapable</key>
+	<true/>
+	<key>NSMicrophoneUsageDescription</key>
+	<string>Oscillo uses microphone input to drive real-time audio-reactive visuals.</string>
+	<key>NSSupportsAutomaticGraphicsSwitching</key>
+	<true/>
+</dict>
+</plist>

--- a/native/AppBundle/OscilloMac.entitlements
+++ b/native/AppBundle/OscilloMac.entitlements
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>com.apple.security.app-sandbox</key>
+	<true/>
+	<key>com.apple.security.device.audio-input</key>
+	<true/>
+	<key>com.apple.security.network.client</key>
+	<true/>
+</dict>
+</plist>

--- a/native/DESIGN_DIRECTION.md
+++ b/native/DESIGN_DIRECTION.md
@@ -1,0 +1,37 @@
+# Native Design Direction
+
+The Swift rewrite is not a strict port of the pre-native Three.js experiment.
+
+The web app is useful source material for the domain: audio reactivity, visual synthesis, musical controls, and exploratory play. It should not be treated as the final layout, visual language, interaction model, or feature checklist for the native app.
+
+## Product North Star
+
+Oscillo Native should feel like a living instrument for sound-driven light.
+
+It should be immediate enough to open on a MacBook Pro and play with in seconds, but deep enough that each control changes the character of the scene. The app should feel native to Apple platforms: fast, tactile, precise, and visually rich without copying a web HUD.
+
+## Creative Principles
+
+- Prefer native interaction patterns over web parity.
+- Let audio shape motion, topology, color, and camera behavior, not only brightness.
+- Make the first screen the instrument, not an explanatory landing page.
+- Keep controls compact and inspectable; the scene should own most of the window.
+- Use Metal for visual identity, not just as a Three.js replacement.
+- Design macOS first for testing and iteration, but avoid choices that would make iOS feel bolted on later.
+- Treat Apple frameworks as creative material: Core Haptics, AVAudioEnvironmentNode, MetalFX, Sound Analysis, Core ML, Foundation Models, SwiftData, App Intents, and SharePlay can all become product features when they serve the experience.
+
+## Near-Term Creative Bets
+
+- **Spectral terrain:** convert FFT bands into a responsive field or relief surface.
+- **Instrument modes:** switch between tunnel, constellation, liquid surface, and spectrogram stage instead of one permanent scene.
+- **Gesture performance:** map trackpad or touch input to camera pressure, particle attraction, and filter sweeps.
+- **Spatial notes:** turn note nodes into actual positioned audio emitters when synthesis is active.
+- **Scene recipes:** save and recall palette/motion/audio mappings as native presets.
+- **Prompted presets:** later, use on-device Foundation Models to generate scene recipes from short prompts when available.
+
+## What Not To Do
+
+- Do not recreate every panel or shader from the web app just because it exists.
+- Do not let the old Three.js scene dictate the native renderer architecture.
+- Do not wait for full feature parity before making the native app feel distinctive.
+- Do not add decorative complexity that makes the app slower to understand or worse to perform.

--- a/native/Package.swift
+++ b/native/Package.swift
@@ -1,0 +1,25 @@
+// swift-tools-version: 6.0
+
+import PackageDescription
+
+let package = Package(
+    name: "OscilloNative",
+    platforms: [
+        .macOS(.v14)
+    ],
+    products: [
+        .library(name: "OscilloCore", targets: ["OscilloCore"]),
+        .executable(name: "OscilloMac", targets: ["OscilloMac"])
+    ],
+    targets: [
+        .target(name: "OscilloCore"),
+        .executableTarget(
+            name: "OscilloMac",
+            dependencies: ["OscilloCore"]
+        ),
+        .testTarget(
+            name: "OscilloCoreTests",
+            dependencies: ["OscilloCore"]
+        )
+    ]
+)

--- a/native/README.md
+++ b/native/README.md
@@ -8,6 +8,7 @@ The current slice is intentionally separate from the existing Next/Three.js app.
 - `OscilloMac`: a macOS SwiftUI + MetalKit app executable.
 - Core XCTest coverage for the shared model and audio analysis contracts.
 - `APPLE_TECH_MAP.md`: current Apple framework research and adoption plan.
+- `DESIGN_DIRECTION.md`: native creative direction and non-parity guidance.
 - `UPDATES.md`: GitHub release update channel and secure OTA path.
 
 ## Requirements
@@ -57,6 +58,8 @@ Native pull requests are checked by `.github/workflows/native-macos.yml`.
 Native release builds are published by `.github/workflows/native-release.yml` using tags like `native-v0.1.0`.
 
 See `UPDATES.md` for the current GitHub Releases update channel and the secure Sparkle OTA install path.
+
+See `DESIGN_DIRECTION.md` before making visual or interaction decisions. The Swift app is allowed to diverge from the old Three.js experiment.
 
 ## Current Scope
 

--- a/native/README.md
+++ b/native/README.md
@@ -1,0 +1,70 @@
+# Oscillo Native
+
+Native Swift rewrite lane for Oscillo.
+
+The current slice is intentionally separate from the existing Next/Three.js app. It provides:
+
+- `OscilloCore`: shared vDSP-backed audio analysis, quality profiles, and deterministic note-field data.
+- `OscilloMac`: a macOS SwiftUI + MetalKit app executable.
+- Core XCTest coverage for the shared model and audio analysis contracts.
+- `APPLE_TECH_MAP.md`: current Apple framework research and adoption plan.
+- `UPDATES.md`: GitHub release update channel and secure OTA path.
+
+## Requirements
+
+- Xcode 26.4.1 or newer
+- Swift 6.2+
+
+If `xcode-select` points at Command Line Tools, prefix commands with:
+
+```bash
+DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer
+```
+
+## Build And Test
+
+```bash
+DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer swift test
+```
+
+```bash
+DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer swift build --product OscilloMac
+```
+
+```bash
+DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer swift run OscilloMac
+```
+
+To build a launchable macOS app bundle:
+
+```bash
+cd native
+DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer ./Scripts/build-macos-app.sh
+open dist/Oscillo.app
+```
+
+To build and open it in one command:
+
+```bash
+cd native
+DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer ./Scripts/run-macos-app.sh
+```
+
+## GitHub CI And Releases
+
+Native pull requests are checked by `.github/workflows/native-macos.yml`.
+
+Native release builds are published by `.github/workflows/native-release.yml` using tags like `native-v0.1.0`.
+
+See `UPDATES.md` for the current GitHub Releases update channel and the secure Sparkle OTA install path.
+
+## Current Scope
+
+The macOS executable opens a SwiftUI window backed by an `MTKView`. It renders an audio-reactive Metal scene using a preview signal by default and can attempt microphone input through `AVAudioEngine`. The visible control panel includes microphone/preview controls, palette selection, intensity, particle density, preview tempo, live audio meters, and a GitHub Releases update check. The bundle template includes `NSMicrophoneUsageDescription` plus sandboxed audio-input and outbound-network entitlements for local signing.
+
+Durable next steps:
+
+- Move shader source into compiled `.metal` files once the app target is packaged as an Xcode project.
+- Add a renderer abstraction so a Metal 4 backend can coexist with the current MetalKit backend.
+- Promote the bundle script into an Xcode app target once the app needs asset catalogs, schemes, and simulator destinations.
+- Add an iOS target that reuses `OscilloCore` and the renderer contracts.

--- a/native/Scripts/build-macos-app.sh
+++ b/native/Scripts/build-macos-app.sh
@@ -22,7 +22,7 @@ case "$CONFIGURATION" in
 esac
 
 swift build --configuration "$CONFIGURATION" --product "$PRODUCT"
-BIN_PATH="$(swift build --configuration "$CONFIGURATION" --show-bin-path)"
+BIN_PATH="$ROOT/.build/$CONFIGURATION"
 EXECUTABLE="$BIN_PATH/$PRODUCT"
 
 if [[ ! -x "$EXECUTABLE" ]]; then

--- a/native/Scripts/build-macos-app.sh
+++ b/native/Scripts/build-macos-app.sh
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+CONFIGURATION="${CONFIGURATION:-debug}"
+PRODUCT="OscilloMac"
+APP_NAME="Oscillo"
+APP_DIR="$ROOT/dist/$APP_NAME.app"
+CONTENTS_DIR="$APP_DIR/Contents"
+MACOS_DIR="$CONTENTS_DIR/MacOS"
+RESOURCES_DIR="$CONTENTS_DIR/Resources"
+INFO_PLIST="$ROOT/AppBundle/Info.plist"
+ENTITLEMENTS="$ROOT/AppBundle/OscilloMac.entitlements"
+
+case "$CONFIGURATION" in
+  debug|release)
+    ;;
+  *)
+    echo "CONFIGURATION must be debug or release" >&2
+    exit 64
+    ;;
+esac
+
+swift build --configuration "$CONFIGURATION" --product "$PRODUCT"
+BIN_PATH="$(swift build --configuration "$CONFIGURATION" --show-bin-path)"
+EXECUTABLE="$BIN_PATH/$PRODUCT"
+
+if [[ ! -x "$EXECUTABLE" ]]; then
+  echo "Expected executable not found: $EXECUTABLE" >&2
+  exit 66
+fi
+
+rm -rf "$APP_DIR"
+mkdir -p "$MACOS_DIR" "$RESOURCES_DIR"
+
+cp "$INFO_PLIST" "$CONTENTS_DIR/Info.plist"
+printf "APPL????" > "$CONTENTS_DIR/PkgInfo"
+cp "$EXECUTABLE" "$MACOS_DIR/$PRODUCT"
+chmod +x "$MACOS_DIR/$PRODUCT"
+
+plutil -lint "$CONTENTS_DIR/Info.plist" >/dev/null
+codesign --force --sign - --entitlements "$ENTITLEMENTS" "$APP_DIR" >/dev/null
+codesign --verify --deep --strict "$APP_DIR"
+
+echo "$APP_DIR"

--- a/native/Scripts/generate-update-manifest.py
+++ b/native/Scripts/generate-update-manifest.py
@@ -1,0 +1,35 @@
+#!/usr/bin/env python3
+import argparse
+import json
+from datetime import datetime, timezone
+from pathlib import Path
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Generate Oscillo native update manifest.")
+    parser.add_argument("--version", required=True)
+    parser.add_argument("--tag", required=True)
+    parser.add_argument("--download-url", required=True)
+    parser.add_argument("--release-url", required=True)
+    parser.add_argument("--sha256", required=True)
+    parser.add_argument("--output", required=True)
+    args = parser.parse_args()
+
+    payload = {
+        "platform": "macos",
+        "version": args.version,
+        "tag": args.tag,
+        "minimumSystemVersion": "14.0",
+        "publishedAt": datetime.now(timezone.utc).isoformat(),
+        "downloadURL": args.download_url,
+        "releaseURL": args.release_url,
+        "sha256": args.sha256,
+    }
+
+    output = Path(args.output)
+    output.parent.mkdir(parents=True, exist_ok=True)
+    output.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+
+if __name__ == "__main__":
+    main()

--- a/native/Scripts/run-macos-app.sh
+++ b/native/Scripts/run-macos-app.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+APP_PATH="$("$ROOT/Scripts/build-macos-app.sh" | tail -n 1)"
+
+open -n "$APP_PATH"
+echo "Opened $APP_PATH"

--- a/native/Sources/OscilloCore/AppVersion.swift
+++ b/native/Sources/OscilloCore/AppVersion.swift
@@ -1,0 +1,37 @@
+import Foundation
+
+public struct AppVersion: Comparable, Equatable, Sendable {
+    public let major: Int
+    public let minor: Int
+    public let patch: Int
+
+    public init?(_ rawValue: String) {
+        let normalized = rawValue
+            .replacing(/^native-v/, with: "")
+            .replacing(/^v/, with: "")
+        let parts = normalized.split(separator: ".")
+        guard parts.count == 3,
+              let major = Int(parts[0]),
+              let minor = Int(parts[1]),
+              let patch = Int(parts[2])
+        else {
+            return nil
+        }
+
+        self.major = major
+        self.minor = minor
+        self.patch = patch
+    }
+
+    public static func < (lhs: AppVersion, rhs: AppVersion) -> Bool {
+        if lhs.major != rhs.major {
+            return lhs.major < rhs.major
+        }
+
+        if lhs.minor != rhs.minor {
+            return lhs.minor < rhs.minor
+        }
+
+        return lhs.patch < rhs.patch
+    }
+}

--- a/native/Sources/OscilloCore/AudioFeatureStore.swift
+++ b/native/Sources/OscilloCore/AudioFeatureStore.swift
@@ -4,7 +4,9 @@ public final class AudioFeatureStore: @unchecked Sendable {
     private let lock = NSLock()
     private var currentFeatures = AudioFeatures.silence
 
-    public init() {}
+    public init() {
+        // Public initializer exposes the store outside the module.
+    }
 
     public func update(_ features: AudioFeatures) {
         lock.lock()

--- a/native/Sources/OscilloCore/AudioFeatureStore.swift
+++ b/native/Sources/OscilloCore/AudioFeatureStore.swift
@@ -1,0 +1,21 @@
+import Foundation
+
+public final class AudioFeatureStore: @unchecked Sendable {
+    private let lock = NSLock()
+    private var currentFeatures = AudioFeatures.silence
+
+    public init() {}
+
+    public func update(_ features: AudioFeatures) {
+        lock.lock()
+        currentFeatures = features
+        lock.unlock()
+    }
+
+    public func snapshot() -> AudioFeatures {
+        lock.lock()
+        let features = currentFeatures
+        lock.unlock()
+        return features
+    }
+}

--- a/native/Sources/OscilloCore/AudioFeatures.swift
+++ b/native/Sources/OscilloCore/AudioFeatures.swift
@@ -81,27 +81,33 @@ public enum AudioFeatureExtractor {
             return (0, 0, 0)
         }
 
-        var bass: [Float] = []
-        var mid: [Float] = []
-        var treble: [Float] = []
+        var bassSum = Float(0)
+        var bassCount = 0
+        var midSum = Float(0)
+        var midCount = 0
+        var trebleSum = Float(0)
+        var trebleCount = 0
 
         for (index, magnitude) in magnitudes.enumerated() {
             let frequency = frequencyForBin(index, binCount: magnitudes.count, sampleRate: sampleRate)
             let normalized = min(max(magnitude, 0), 1)
 
             if frequency < 250 {
-                bass.append(normalized)
+                bassSum += normalized
+                bassCount += 1
             } else if frequency < 4_000 {
-                mid.append(normalized)
+                midSum += normalized
+                midCount += 1
             } else {
-                treble.append(normalized)
+                trebleSum += normalized
+                trebleCount += 1
             }
         }
 
         return (
-            average(bass),
-            average(mid),
-            average(treble)
+            average(sum: bassSum, count: bassCount),
+            average(sum: midSum, count: midCount),
+            average(sum: trebleSum, count: trebleCount)
         )
     }
 
@@ -165,8 +171,8 @@ public enum AudioFeatureExtractor {
         return Float(index) * (sampleRate / 2) / Float(binCount)
     }
 
-    private static func average(_ values: [Float]) -> Float {
-        guard !values.isEmpty else { return 0 }
-        return values.reduce(0, +) / Float(values.count)
+    private static func average(sum: Float, count: Int) -> Float {
+        guard count > 0 else { return 0 }
+        return sum / Float(count)
     }
 }

--- a/native/Sources/OscilloCore/AudioFeatures.swift
+++ b/native/Sources/OscilloCore/AudioFeatures.swift
@@ -1,0 +1,172 @@
+import Foundation
+
+public struct AudioFeatures: Equatable, Sendable {
+    public var volume: Float
+    public var bassEnergy: Float
+    public var midEnergy: Float
+    public var trebleEnergy: Float
+    public var peakFrequency: Float
+    public var spectralCentroid: Float
+    public var rms: Float
+    public var zeroCrossingRate: Float
+
+    public init(
+        volume: Float,
+        bassEnergy: Float,
+        midEnergy: Float,
+        trebleEnergy: Float,
+        peakFrequency: Float,
+        spectralCentroid: Float,
+        rms: Float,
+        zeroCrossingRate: Float
+    ) {
+        self.volume = volume
+        self.bassEnergy = bassEnergy
+        self.midEnergy = midEnergy
+        self.trebleEnergy = trebleEnergy
+        self.peakFrequency = peakFrequency
+        self.spectralCentroid = spectralCentroid
+        self.rms = rms
+        self.zeroCrossingRate = zeroCrossingRate
+    }
+
+    public static let silence = AudioFeatures(
+        volume: 0,
+        bassEnergy: 0,
+        midEnergy: 0,
+        trebleEnergy: 0,
+        peakFrequency: 0,
+        spectralCentroid: 0,
+        rms: 0,
+        zeroCrossingRate: 0
+    )
+}
+
+public enum AudioFeatureExtractor {
+    public static func extract(
+        frequencyMagnitudes: [Float],
+        timeDomainSamples: [Float],
+        sampleRate: Float
+    ) -> AudioFeatures {
+        let rms = calculateRMS(timeDomainSamples)
+        let bands = calculateBands(frequencyMagnitudes, sampleRate: sampleRate)
+
+        return AudioFeatures(
+            volume: rms,
+            bassEnergy: bands.bass,
+            midEnergy: bands.mid,
+            trebleEnergy: bands.treble,
+            peakFrequency: calculatePeakFrequency(frequencyMagnitudes, sampleRate: sampleRate),
+            spectralCentroid: calculateSpectralCentroid(frequencyMagnitudes, sampleRate: sampleRate),
+            rms: rms,
+            zeroCrossingRate: calculateZeroCrossingRate(timeDomainSamples)
+        )
+    }
+
+    private static func calculateRMS(_ samples: [Float]) -> Float {
+        guard !samples.isEmpty else { return 0 }
+
+        let sum = samples.reduce(Float(0)) { partial, sample in
+            partial + sample * sample
+        }
+
+        return sqrt(sum / Float(samples.count))
+    }
+
+    private static func calculateBands(
+        _ magnitudes: [Float],
+        sampleRate: Float
+    ) -> (bass: Float, mid: Float, treble: Float) {
+        guard !magnitudes.isEmpty, sampleRate > 0 else {
+            return (0, 0, 0)
+        }
+
+        var bass: [Float] = []
+        var mid: [Float] = []
+        var treble: [Float] = []
+
+        for (index, magnitude) in magnitudes.enumerated() {
+            let frequency = frequencyForBin(index, binCount: magnitudes.count, sampleRate: sampleRate)
+            let normalized = min(max(magnitude, 0), 1)
+
+            if frequency < 250 {
+                bass.append(normalized)
+            } else if frequency < 4_000 {
+                mid.append(normalized)
+            } else {
+                treble.append(normalized)
+            }
+        }
+
+        return (
+            average(bass),
+            average(mid),
+            average(treble)
+        )
+    }
+
+    private static func calculatePeakFrequency(
+        _ magnitudes: [Float],
+        sampleRate: Float
+    ) -> Float {
+        guard !magnitudes.isEmpty, sampleRate > 0 else { return 0 }
+
+        var peakIndex = 0
+        var peakMagnitude = Float.leastNormalMagnitude
+
+        for (index, magnitude) in magnitudes.enumerated() where magnitude > peakMagnitude {
+            peakIndex = index
+            peakMagnitude = magnitude
+        }
+
+        return peakMagnitude > 0
+            ? frequencyForBin(peakIndex, binCount: magnitudes.count, sampleRate: sampleRate)
+            : 0
+    }
+
+    private static func calculateSpectralCentroid(
+        _ magnitudes: [Float],
+        sampleRate: Float
+    ) -> Float {
+        guard !magnitudes.isEmpty, sampleRate > 0 else { return 0 }
+
+        var weightedSum = Float(0)
+        var magnitudeSum = Float(0)
+
+        for (index, magnitude) in magnitudes.enumerated() {
+            let normalized = max(magnitude, 0)
+            let frequency = frequencyForBin(index, binCount: magnitudes.count, sampleRate: sampleRate)
+            weightedSum += frequency * normalized
+            magnitudeSum += normalized
+        }
+
+        return magnitudeSum > 0 ? weightedSum / magnitudeSum : 0
+    }
+
+    private static func calculateZeroCrossingRate(_ samples: [Float]) -> Float {
+        guard samples.count > 1 else { return 0 }
+
+        var crossings = 0
+        for index in 1..<samples.count {
+            if samples[index - 1] * samples[index] < 0 {
+                crossings += 1
+            }
+        }
+
+        return Float(crossings) / Float(samples.count)
+    }
+
+    private static func frequencyForBin(
+        _ index: Int,
+        binCount: Int,
+        sampleRate: Float
+    ) -> Float {
+        guard binCount > 0 else { return 0 }
+        return Float(index) * (sampleRate / 2) / Float(binCount)
+    }
+
+    private static func average(_ values: [Float]) -> Float {
+        guard !values.isEmpty else { return 0 }
+        return values.reduce(0, +) / Float(values.count)
+    }
+}

--- a/native/Sources/OscilloCore/AudioFeatures.swift
+++ b/native/Sources/OscilloCore/AudioFeatures.swift
@@ -1,5 +1,19 @@
 import Foundation
 
+public struct AudioEnergyBands: Equatable, Sendable {
+    public var bass: Float
+    public var mid: Float
+    public var treble: Float
+
+    public init(bass: Float, mid: Float, treble: Float) {
+        self.bass = bass
+        self.mid = mid
+        self.treble = treble
+    }
+
+    public static let silence = AudioEnergyBands(bass: 0, mid: 0, treble: 0)
+}
+
 public struct AudioFeatures: Equatable, Sendable {
     public var volume: Float
     public var bassEnergy: Float
@@ -12,18 +26,16 @@ public struct AudioFeatures: Equatable, Sendable {
 
     public init(
         volume: Float,
-        bassEnergy: Float,
-        midEnergy: Float,
-        trebleEnergy: Float,
+        bands: AudioEnergyBands,
         peakFrequency: Float,
         spectralCentroid: Float,
         rms: Float,
         zeroCrossingRate: Float
     ) {
         self.volume = volume
-        self.bassEnergy = bassEnergy
-        self.midEnergy = midEnergy
-        self.trebleEnergy = trebleEnergy
+        self.bassEnergy = bands.bass
+        self.midEnergy = bands.mid
+        self.trebleEnergy = bands.treble
         self.peakFrequency = peakFrequency
         self.spectralCentroid = spectralCentroid
         self.rms = rms
@@ -32,9 +44,7 @@ public struct AudioFeatures: Equatable, Sendable {
 
     public static let silence = AudioFeatures(
         volume: 0,
-        bassEnergy: 0,
-        midEnergy: 0,
-        trebleEnergy: 0,
+        bands: .silence,
         peakFrequency: 0,
         spectralCentroid: 0,
         rms: 0,
@@ -53,9 +63,7 @@ public enum AudioFeatureExtractor {
 
         return AudioFeatures(
             volume: rms,
-            bassEnergy: bands.bass,
-            midEnergy: bands.mid,
-            trebleEnergy: bands.treble,
+            bands: bands,
             peakFrequency: calculatePeakFrequency(frequencyMagnitudes, sampleRate: sampleRate),
             spectralCentroid: calculateSpectralCentroid(frequencyMagnitudes, sampleRate: sampleRate),
             rms: rms,
@@ -76,9 +84,9 @@ public enum AudioFeatureExtractor {
     private static func calculateBands(
         _ magnitudes: [Float],
         sampleRate: Float
-    ) -> (bass: Float, mid: Float, treble: Float) {
+    ) -> AudioEnergyBands {
         guard !magnitudes.isEmpty, sampleRate > 0 else {
-            return (0, 0, 0)
+            return .silence
         }
 
         var bassSum = Float(0)
@@ -104,10 +112,10 @@ public enum AudioFeatureExtractor {
             }
         }
 
-        return (
-            average(sum: bassSum, count: bassCount),
-            average(sum: midSum, count: midCount),
-            average(sum: trebleSum, count: trebleCount)
+        return AudioEnergyBands(
+            bass: average(sum: bassSum, count: bassCount),
+            mid: average(sum: midSum, count: midCount),
+            treble: average(sum: trebleSum, count: trebleCount)
         )
     }
 

--- a/native/Sources/OscilloCore/NativeReleaseSelector.swift
+++ b/native/Sources/OscilloCore/NativeReleaseSelector.swift
@@ -1,0 +1,23 @@
+public struct NativeReleaseCandidate: Equatable, Sendable {
+    public let tagName: String
+    public let version: AppVersion
+
+    public init?(tagName: String) {
+        guard tagName.hasPrefix("native-v"),
+              let version = AppVersion(tagName)
+        else {
+            return nil
+        }
+
+        self.tagName = tagName
+        self.version = version
+    }
+}
+
+public enum NativeReleaseSelector {
+    public static func newest(in tagNames: [String]) -> NativeReleaseCandidate? {
+        tagNames
+            .compactMap { NativeReleaseCandidate(tagName: $0) }
+            .max { $0.version < $1.version }
+    }
+}

--- a/native/Sources/OscilloCore/NoteField.swift
+++ b/native/Sources/OscilloCore/NoteField.swift
@@ -1,0 +1,67 @@
+import simd
+
+public enum NoteKind: String, Equatable, Sendable {
+    case note
+    case chord
+    case beat
+}
+
+public struct NoteNode: Equatable, Sendable, Identifiable {
+    public let id: String
+    public let position: SIMD3<Float>
+    public let note: String
+    public let hueDegrees: Float
+    public let kind: NoteKind
+
+    public init(
+        id: String,
+        position: SIMD3<Float>,
+        note: String,
+        hueDegrees: Float,
+        kind: NoteKind
+    ) {
+        self.id = id
+        self.position = position
+        self.note = note
+        self.hueDegrees = hueDegrees
+        self.kind = kind
+    }
+}
+
+public enum NoteField {
+    public static func generate(scaleNotes: [String], maxCount: Int = 12) -> [NoteNode] {
+        let count = min(scaleNotes.count, maxCount)
+        guard count > 0 else { return [] }
+
+        return (0..<count).map { index in
+            let t = Float(index) / Float(count)
+            let spiralRadius = Float(6) + sin(t * .pi * 4) * 2
+            let spiralHeight = (t - 0.5) * 8
+            let angle = t * .pi * 6
+
+            return NoteNode(
+                id: "\(scaleNotes[index])-\(index)",
+                position: SIMD3<Float>(
+                    cos(angle) * spiralRadius,
+                    spiralHeight,
+                    sin(angle) * spiralRadius
+                ),
+                note: scaleNotes[index],
+                hueDegrees: t * 360,
+                kind: kind(for: index)
+            )
+        }
+    }
+
+    private static func kind(for index: Int) -> NoteKind {
+        if index.isMultiple(of: 4) {
+            return .chord
+        }
+
+        if index.isMultiple(of: 3) {
+            return .beat
+        }
+
+        return .note
+    }
+}

--- a/native/Sources/OscilloCore/QualityProfile.swift
+++ b/native/Sources/OscilloCore/QualityProfile.swift
@@ -1,0 +1,62 @@
+public enum QualityLevel: String, CaseIterable, Equatable, Sendable {
+    case low
+    case medium
+    case high
+}
+
+public struct QualityProfile: Equatable, Sendable {
+    public let level: QualityLevel
+    public let starCountScale: Float
+    public let particleScale: Float
+    public let shadowsEnabled: Bool
+    public let postProcessingEnabled: Bool
+
+    public init(
+        level: QualityLevel,
+        starCountScale: Float,
+        particleScale: Float,
+        shadowsEnabled: Bool,
+        postProcessingEnabled: Bool
+    ) {
+        self.level = level
+        self.starCountScale = starCountScale
+        self.particleScale = particleScale
+        self.shadowsEnabled = shadowsEnabled
+        self.postProcessingEnabled = postProcessingEnabled
+    }
+
+    public static let low = QualityProfile(
+        level: .low,
+        starCountScale: 0.4,
+        particleScale: 0.4,
+        shadowsEnabled: false,
+        postProcessingEnabled: false
+    )
+
+    public static let medium = QualityProfile(
+        level: .medium,
+        starCountScale: 0.7,
+        particleScale: 0.7,
+        shadowsEnabled: true,
+        postProcessingEnabled: true
+    )
+
+    public static let high = QualityProfile(
+        level: .high,
+        starCountScale: 1.0,
+        particleScale: 1.0,
+        shadowsEnabled: true,
+        postProcessingEnabled: true
+    )
+
+    public static func profile(for level: QualityLevel) -> QualityProfile {
+        switch level {
+        case .low:
+            low
+        case .medium:
+            medium
+        case .high:
+            high
+        }
+    }
+}

--- a/native/Sources/OscilloCore/SceneSettings.swift
+++ b/native/Sources/OscilloCore/SceneSettings.swift
@@ -53,7 +53,7 @@ public struct SceneSettings: Equatable, Sendable {
         self.palette = palette
     }
 
-    public static let `default` = SceneSettings(
+    public static let standard = SceneSettings(
         visualGain: 1.0,
         particleDensity: 0.9,
         previewTempo: 1.0,
@@ -65,7 +65,7 @@ public final class SceneSettingsStore: @unchecked Sendable {
     private let lock = NSLock()
     private var currentSettings: SceneSettings
 
-    public init(initialSettings: SceneSettings = .default) {
+    public init(initialSettings: SceneSettings = .standard) {
         self.currentSettings = initialSettings
     }
 

--- a/native/Sources/OscilloCore/SceneSettings.swift
+++ b/native/Sources/OscilloCore/SceneSettings.swift
@@ -1,0 +1,90 @@
+import Foundation
+
+public enum ScenePalette: String, CaseIterable, Equatable, Identifiable, Sendable {
+    case neon
+    case aurora
+    case solar
+    case mono
+
+    public var id: String { rawValue }
+
+    public var displayName: String {
+        switch self {
+        case .neon:
+            "Neon"
+        case .aurora:
+            "Aurora"
+        case .solar:
+            "Solar"
+        case .mono:
+            "Mono"
+        }
+    }
+
+    public var uniformIndex: Int32 {
+        switch self {
+        case .neon:
+            0
+        case .aurora:
+            1
+        case .solar:
+            2
+        case .mono:
+            3
+        }
+    }
+}
+
+public struct SceneSettings: Equatable, Sendable {
+    public var visualGain: Float
+    public var particleDensity: Float
+    public var previewTempo: Float
+    public var palette: ScenePalette
+
+    public init(
+        visualGain: Float,
+        particleDensity: Float,
+        previewTempo: Float,
+        palette: ScenePalette
+    ) {
+        self.visualGain = visualGain.clamped(to: 0.25...2.0)
+        self.particleDensity = particleDensity.clamped(to: 0.15...1.5)
+        self.previewTempo = previewTempo.clamped(to: 0.5...2.0)
+        self.palette = palette
+    }
+
+    public static let `default` = SceneSettings(
+        visualGain: 1.0,
+        particleDensity: 0.9,
+        previewTempo: 1.0,
+        palette: .neon
+    )
+}
+
+public final class SceneSettingsStore: @unchecked Sendable {
+    private let lock = NSLock()
+    private var currentSettings: SceneSettings
+
+    public init(initialSettings: SceneSettings = .default) {
+        self.currentSettings = initialSettings
+    }
+
+    public func update(_ settings: SceneSettings) {
+        lock.lock()
+        currentSettings = settings
+        lock.unlock()
+    }
+
+    public func snapshot() -> SceneSettings {
+        lock.lock()
+        let settings = currentSettings
+        lock.unlock()
+        return settings
+    }
+}
+
+private extension Float {
+    func clamped(to range: ClosedRange<Float>) -> Float {
+        min(max(self, range.lowerBound), range.upperBound)
+    }
+}

--- a/native/Sources/OscilloCore/VDSPFrequencyAnalyzer.swift
+++ b/native/Sources/OscilloCore/VDSPFrequencyAnalyzer.swift
@@ -56,44 +56,51 @@ public final class VDSPFrequencyAnalyzer: @unchecked Sendable {
                     imagp: imaginaryPointer.baseAddress!
                 )
 
-                input.withUnsafeBufferPointer { inputPointer in
-                    inputPointer.baseAddress!.withMemoryRebound(
-                        to: DSPComplex.self,
-                        capacity: halfCount
-                    ) { complexPointer in
-                        vDSP_ctoz(
-                            complexPointer,
-                            2,
-                            &splitComplex,
-                            1,
-                            vDSP_Length(halfCount)
-                        )
-                    }
-                }
-
-                vDSP_fft_zrip(
-                    fftSetup,
-                    &splitComplex,
-                    1,
-                    log2SampleCount,
-                    FFTDirection(FFT_FORWARD)
-                )
-
-                splitComplex.realp[0] = 0
-                splitComplex.imagp[0] = 0
-
-                vDSP_zvmags(
-                    &splitComplex,
-                    1,
-                    &powers,
-                    1,
-                    vDSP_Length(halfCount)
-                )
+                copyInput(input, into: &splitComplex)
+                transform(&splitComplex, powers: &powers)
             }
         }
 
         let scale = Float(2) / Float(sampleCount)
         return powers.map { sqrt(max($0, 0)) * scale }
+    }
+
+    private func copyInput(_ input: [Float], into splitComplex: inout DSPSplitComplex) {
+        input.withUnsafeBufferPointer { inputPointer in
+            inputPointer.baseAddress!.withMemoryRebound(
+                to: DSPComplex.self,
+                capacity: halfCount
+            ) { complexPointer in
+                vDSP_ctoz(
+                    complexPointer,
+                    2,
+                    &splitComplex,
+                    1,
+                    vDSP_Length(halfCount)
+                )
+            }
+        }
+    }
+
+    private func transform(_ splitComplex: inout DSPSplitComplex, powers: inout [Float]) {
+        vDSP_fft_zrip(
+            fftSetup,
+            &splitComplex,
+            1,
+            log2SampleCount,
+            FFTDirection(FFT_FORWARD)
+        )
+
+        splitComplex.realp[0] = 0
+        splitComplex.imagp[0] = 0
+
+        vDSP_zvmags(
+            &splitComplex,
+            1,
+            &powers,
+            1,
+            vDSP_Length(halfCount)
+        )
     }
 }
 

--- a/native/Sources/OscilloCore/VDSPFrequencyAnalyzer.swift
+++ b/native/Sources/OscilloCore/VDSPFrequencyAnalyzer.swift
@@ -1,0 +1,101 @@
+import Accelerate
+import Foundation
+
+public final class VDSPFrequencyAnalyzer: @unchecked Sendable {
+    public let sampleCount: Int
+
+    private let halfCount: Int
+    private let log2SampleCount: vDSP_Length
+    private let fftSetup: FFTSetup
+
+    public init?(sampleCount: Int) {
+        guard sampleCount >= 2, sampleCount.isPowerOfTwo else {
+            return nil
+        }
+
+        let log2Value = vDSP_Length(log2(Double(sampleCount)))
+        guard let setup = vDSP_create_fftsetup(log2Value, FFTRadix(kFFTRadix2)) else {
+            return nil
+        }
+
+        self.sampleCount = sampleCount
+        self.halfCount = sampleCount / 2
+        self.log2SampleCount = log2Value
+        self.fftSetup = setup
+    }
+
+    deinit {
+        vDSP_destroy_fftsetup(fftSetup)
+    }
+
+    public func magnitudes(for samples: [Float], applyHannWindow: Bool = true) -> [Float] {
+        var input = Array(repeating: Float(0), count: sampleCount)
+        let copyCount = min(samples.count, sampleCount)
+
+        if copyCount > 0 {
+            input.replaceSubrange(0..<copyCount, with: samples[0..<copyCount])
+        }
+
+        if applyHannWindow {
+            var window = Array(repeating: Float(0), count: sampleCount)
+            vDSP_hann_window(&window, vDSP_Length(sampleCount), Int32(vDSP_HANN_NORM))
+            vDSP_vmul(input, 1, window, 1, &input, 1, vDSP_Length(sampleCount))
+        }
+
+        var real = Array(repeating: Float(0), count: halfCount)
+        var imaginary = Array(repeating: Float(0), count: halfCount)
+        var powers = Array(repeating: Float(0), count: halfCount)
+
+        real.withUnsafeMutableBufferPointer { realPointer in
+            imaginary.withUnsafeMutableBufferPointer { imaginaryPointer in
+                var splitComplex = DSPSplitComplex(
+                    realp: realPointer.baseAddress!,
+                    imagp: imaginaryPointer.baseAddress!
+                )
+
+                input.withUnsafeBufferPointer { inputPointer in
+                    inputPointer.baseAddress!.withMemoryRebound(
+                        to: DSPComplex.self,
+                        capacity: halfCount
+                    ) { complexPointer in
+                        vDSP_ctoz(
+                            complexPointer,
+                            2,
+                            &splitComplex,
+                            1,
+                            vDSP_Length(halfCount)
+                        )
+                    }
+                }
+
+                vDSP_fft_zrip(
+                    fftSetup,
+                    &splitComplex,
+                    1,
+                    log2SampleCount,
+                    FFTDirection(FFT_FORWARD)
+                )
+
+                splitComplex.realp[0] = 0
+                splitComplex.imagp[0] = 0
+
+                vDSP_zvmags(
+                    &splitComplex,
+                    1,
+                    &powers,
+                    1,
+                    vDSP_Length(halfCount)
+                )
+            }
+        }
+
+        let scale = Float(2) / Float(sampleCount)
+        return powers.map { sqrt(max($0, 0)) * scale }
+    }
+}
+
+private extension Int {
+    var isPowerOfTwo: Bool {
+        self > 0 && (self & (self - 1)) == 0
+    }
+}

--- a/native/Sources/OscilloCore/VDSPFrequencyAnalyzer.swift
+++ b/native/Sources/OscilloCore/VDSPFrequencyAnalyzer.swift
@@ -7,6 +7,7 @@ public final class VDSPFrequencyAnalyzer: @unchecked Sendable {
     private let halfCount: Int
     private let log2SampleCount: vDSP_Length
     private let fftSetup: FFTSetup
+    private let hannWindow: [Float]
 
     public init?(sampleCount: Int) {
         guard sampleCount >= 2, sampleCount.isPowerOfTwo else {
@@ -22,6 +23,10 @@ public final class VDSPFrequencyAnalyzer: @unchecked Sendable {
         self.halfCount = sampleCount / 2
         self.log2SampleCount = log2Value
         self.fftSetup = setup
+
+        var window = Array(repeating: Float(0), count: sampleCount)
+        vDSP_hann_window(&window, vDSP_Length(sampleCount), Int32(vDSP_HANN_NORM))
+        self.hannWindow = window
     }
 
     deinit {
@@ -37,9 +42,7 @@ public final class VDSPFrequencyAnalyzer: @unchecked Sendable {
         }
 
         if applyHannWindow {
-            var window = Array(repeating: Float(0), count: sampleCount)
-            vDSP_hann_window(&window, vDSP_Length(sampleCount), Int32(vDSP_HANN_NORM))
-            vDSP_vmul(input, 1, window, 1, &input, 1, vDSP_Length(sampleCount))
+            vDSP_vmul(input, 1, hannWindow, 1, &input, 1, vDSP_Length(sampleCount))
         }
 
         var real = Array(repeating: Float(0), count: halfCount)

--- a/native/Sources/OscilloMac/ContentView.swift
+++ b/native/Sources/OscilloMac/ContentView.swift
@@ -1,0 +1,202 @@
+import OscilloCore
+import SwiftUI
+
+struct ContentView: View {
+    @ObservedObject var audioEngine: LiveAudioEngine
+    @ObservedObject var sceneController: SceneController
+    @StateObject private var updateController = UpdateController()
+
+    var body: some View {
+        ZStack(alignment: .topLeading) {
+            OscilloMetalSurface(
+                featureStore: audioEngine.featureStore,
+                settingsStore: sceneController.settingsStore,
+                isActive: audioEngine.isRunning || audioEngine.isPreviewing
+            )
+            .ignoresSafeArea()
+
+            ControlPanel(
+                audioEngine: audioEngine,
+                sceneController: sceneController,
+                updateController: updateController
+            )
+                .padding(18)
+        }
+        .task {
+            audioEngine.startPreview()
+        }
+    }
+}
+
+private struct ControlPanel: View {
+    @ObservedObject var audioEngine: LiveAudioEngine
+    @ObservedObject var sceneController: SceneController
+    @ObservedObject var updateController: UpdateController
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 16) {
+            VStack(alignment: .leading, spacing: 4) {
+                Text("Oscillo")
+                    .font(.system(size: 20, weight: .semibold, design: .rounded))
+                Text(audioEngine.statusMessage)
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+            }
+
+            HStack(spacing: 10) {
+                Button(audioEngine.isRunning ? "Stop Input" : "Use Microphone") {
+                    if audioEngine.isRunning {
+                        audioEngine.stopMicrophone()
+                    } else {
+                        audioEngine.startMicrophone()
+                    }
+                }
+                .buttonStyle(.borderedProminent)
+
+                Button(audioEngine.isPreviewing ? "Pause Preview" : "Preview") {
+                    if audioEngine.isPreviewing {
+                        audioEngine.stopPreview(resetFeatures: true)
+                    } else {
+                        audioEngine.startPreview()
+                    }
+                }
+                .buttonStyle(.bordered)
+            }
+
+            Picker("Palette", selection: Binding(
+                get: { sceneController.settings.palette },
+                set: { sceneController.setPalette($0) }
+            )) {
+                ForEach(ScenePalette.allCases) { palette in
+                    Text(palette.displayName).tag(palette)
+                }
+            }
+            .pickerStyle(.segmented)
+
+            ControlSlider(
+                title: "Intensity",
+                value: Binding(
+                    get: { sceneController.settings.visualGain },
+                    set: { sceneController.setVisualGain($0) }
+                ),
+                range: 0.25...2.0
+            )
+
+            ControlSlider(
+                title: "Particles",
+                value: Binding(
+                    get: { sceneController.settings.particleDensity },
+                    set: { sceneController.setParticleDensity($0) }
+                ),
+                range: 0.15...1.5
+            )
+
+            ControlSlider(
+                title: "Preview Tempo",
+                value: Binding(
+                    get: { sceneController.settings.previewTempo },
+                    set: { sceneController.setPreviewTempo($0) }
+                ),
+                range: 0.5...2.0
+            )
+
+            Divider()
+                .overlay(.white.opacity(0.16))
+
+            FeatureMeter(title: "Level", value: audioEngine.features.volume)
+            FeatureMeter(title: "Bass", value: audioEngine.features.bassEnergy)
+            FeatureMeter(title: "Mid", value: audioEngine.features.midEnergy)
+            FeatureMeter(title: "Treble", value: audioEngine.features.trebleEnergy)
+
+            Divider()
+                .overlay(.white.opacity(0.16))
+
+            VStack(alignment: .leading, spacing: 8) {
+                HStack(spacing: 10) {
+                    Button(updateController.isChecking ? "Checking..." : "Check Updates") {
+                        updateController.checkNow()
+                    }
+                    .disabled(updateController.isChecking)
+
+                    Button("Open Release") {
+                        updateController.openReleasePage()
+                    }
+                    .disabled(updateController.releaseURL == nil)
+                }
+
+                Text(updateController.statusText)
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+                    .fixedSize(horizontal: false, vertical: true)
+            }
+        }
+        .padding(18)
+        .frame(width: 312, alignment: .leading)
+        .background(.black.opacity(0.58), in: RoundedRectangle(cornerRadius: 8))
+        .overlay(
+            RoundedRectangle(cornerRadius: 8)
+                .stroke(.white.opacity(0.14), lineWidth: 1)
+        )
+    }
+}
+
+private struct ControlSlider: View {
+    let title: String
+    @Binding var value: Float
+    let range: ClosedRange<Float>
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 6) {
+            HStack {
+                Text(title)
+                Spacer()
+                Text(value.formatted(.number.precision(.fractionLength(2))))
+                    .monospacedDigit()
+                    .foregroundStyle(.secondary)
+            }
+            .font(.caption)
+
+            Slider(
+                value: Binding(
+                    get: { Double(value) },
+                    set: { value = Float($0) }
+                ),
+                in: Double(range.lowerBound)...Double(range.upperBound)
+            )
+        }
+        .foregroundStyle(.white)
+    }
+}
+
+private struct FeatureMeter: View {
+    let title: String
+    let value: Float
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 5) {
+            HStack {
+                Text(title)
+                Spacer()
+                Text(value.formatted(.number.precision(.fractionLength(2))))
+                    .monospacedDigit()
+            }
+            .font(.caption)
+
+            GeometryReader { proxy in
+                RoundedRectangle(cornerRadius: 2)
+                    .fill(.white.opacity(0.14))
+                    .overlay(alignment: .leading) {
+                        RoundedRectangle(cornerRadius: 2)
+                            .fill(LinearGradient(
+                                colors: [.cyan, .pink],
+                                startPoint: .leading,
+                                endPoint: .trailing
+                            ))
+                            .frame(width: proxy.size.width * CGFloat(min(max(value, 0), 1)))
+                    }
+            }
+            .frame(height: 5)
+        }
+        .foregroundStyle(.white)
+    }
+}

--- a/native/Sources/OscilloMac/GitHubUpdateService.swift
+++ b/native/Sources/OscilloMac/GitHubUpdateService.swift
@@ -14,13 +14,22 @@ enum UpdateCheckResult: Equatable {
     case updateAvailable(AvailableUpdate)
 }
 
-enum GitHubUpdateServiceError: Error {
+enum GitHubUpdateServiceError: Error, LocalizedError {
     case invalidResponse
     case invalidCurrentVersion
+
+    var errorDescription: String? {
+        switch self {
+        case .invalidResponse:
+            "GitHub Releases returned an unexpected response."
+        case .invalidCurrentVersion:
+            "This Oscillo build has an invalid version number."
+        }
+    }
 }
 
 final class GitHubUpdateService: @unchecked Sendable {
-    private let releaseURL = URL(string: "https://api.github.com/repos/zachyzissou/Oscillo/releases/latest")!
+    private let releasesURL = URL(string: "https://api.github.com/repos/zachyzissou/Oscillo/releases?per_page=20")!
     private let session: URLSession
 
     init(session: URLSession = .shared) {
@@ -32,7 +41,7 @@ final class GitHubUpdateService: @unchecked Sendable {
             throw GitHubUpdateServiceError.invalidCurrentVersion
         }
 
-        var request = URLRequest(url: releaseURL)
+        var request = URLRequest(url: releasesURL)
         request.setValue("application/vnd.github+json", forHTTPHeaderField: "Accept")
         request.setValue("OscilloNative", forHTTPHeaderField: "User-Agent")
 
@@ -49,17 +58,19 @@ final class GitHubUpdateService: @unchecked Sendable {
             throw GitHubUpdateServiceError.invalidResponse
         }
 
-        let release = try JSONDecoder().decode(GitHubRelease.self, from: data)
-        guard let remoteVersion = AppVersion(release.tagName) else {
-            return .current
+        let releases = try JSONDecoder().decode([GitHubRelease].self, from: data)
+        guard let nativeRelease = NativeReleaseSelector.newest(in: releases.map(\.tagName)),
+              let release = releases.first(where: { $0.tagName == nativeRelease.tagName })
+        else {
+            return .noRelease
         }
 
-        guard remoteVersion > currentVersion else {
+        guard nativeRelease.version > currentVersion else {
             return .current
         }
 
         return .updateAvailable(AvailableUpdate(
-            version: remoteVersion,
+            version: nativeRelease.version,
             tagName: release.tagName,
             releaseURL: release.htmlURL,
             downloadURL: release.assets.first { asset in

--- a/native/Sources/OscilloMac/GitHubUpdateService.swift
+++ b/native/Sources/OscilloMac/GitHubUpdateService.swift
@@ -1,0 +1,92 @@
+import Foundation
+import OscilloCore
+
+struct AvailableUpdate: Equatable {
+    let version: AppVersion
+    let tagName: String
+    let releaseURL: URL
+    let downloadURL: URL?
+}
+
+enum UpdateCheckResult: Equatable {
+    case noRelease
+    case current
+    case updateAvailable(AvailableUpdate)
+}
+
+enum GitHubUpdateServiceError: Error {
+    case invalidResponse
+    case invalidCurrentVersion
+}
+
+final class GitHubUpdateService: @unchecked Sendable {
+    private let releaseURL = URL(string: "https://api.github.com/repos/zachyzissou/Oscillo/releases/latest")!
+    private let session: URLSession
+
+    init(session: URLSession = .shared) {
+        self.session = session
+    }
+
+    func checkForUpdates(currentVersionString: String) async throws -> UpdateCheckResult {
+        guard let currentVersion = AppVersion(currentVersionString) else {
+            throw GitHubUpdateServiceError.invalidCurrentVersion
+        }
+
+        var request = URLRequest(url: releaseURL)
+        request.setValue("application/vnd.github+json", forHTTPHeaderField: "Accept")
+        request.setValue("OscilloNative", forHTTPHeaderField: "User-Agent")
+
+        let (data, response) = try await session.data(for: request)
+        guard let httpResponse = response as? HTTPURLResponse else {
+            throw GitHubUpdateServiceError.invalidResponse
+        }
+
+        if httpResponse.statusCode == 404 {
+            return .noRelease
+        }
+
+        guard 200..<300 ~= httpResponse.statusCode else {
+            throw GitHubUpdateServiceError.invalidResponse
+        }
+
+        let release = try JSONDecoder().decode(GitHubRelease.self, from: data)
+        guard let remoteVersion = AppVersion(release.tagName) else {
+            return .current
+        }
+
+        guard remoteVersion > currentVersion else {
+            return .current
+        }
+
+        return .updateAvailable(AvailableUpdate(
+            version: remoteVersion,
+            tagName: release.tagName,
+            releaseURL: release.htmlURL,
+            downloadURL: release.assets.first { asset in
+                asset.name.hasSuffix(".zip") && asset.name.contains("Oscillo-macOS")
+            }?.browserDownloadURL
+        ))
+    }
+}
+
+private struct GitHubRelease: Decodable {
+    let tagName: String
+    let htmlURL: URL
+    let assets: [GitHubReleaseAsset]
+
+    enum CodingKeys: String, CodingKey {
+        case tagName = "tag_name"
+        case htmlURL = "html_url"
+        case assets
+    }
+}
+
+private struct GitHubReleaseAsset: Decodable {
+    let name: String
+    let browserDownloadURL: URL
+
+    enum CodingKeys: String, CodingKey {
+        case name
+        case browserDownloadURL = "browser_download_url"
+    }
+}

--- a/native/Sources/OscilloMac/GitHubUpdateService.swift
+++ b/native/Sources/OscilloMac/GitHubUpdateService.swift
@@ -29,11 +29,15 @@ enum GitHubUpdateServiceError: Error, LocalizedError {
 }
 
 final class GitHubUpdateService: @unchecked Sendable {
-    private let releasesURL = URL(string: "https://api.github.com/repos/zachyzissou/Oscillo/releases?per_page=20")!
+    private let releasesURL: URL
     private let session: URLSession
 
-    init(session: URLSession = .shared) {
+    init(
+        session: URLSession = .shared,
+        releasesURL: URL = GitHubUpdateService.defaultReleasesURL()
+    ) {
         self.session = session
+        self.releasesURL = releasesURL
     }
 
     func checkForUpdates(currentVersionString: String) async throws -> UpdateCheckResult {
@@ -77,6 +81,17 @@ final class GitHubUpdateService: @unchecked Sendable {
                 asset.name.hasSuffix(".zip") && asset.name.contains("Oscillo-macOS")
             }?.browserDownloadURL
         ))
+    }
+
+    private static func defaultReleasesURL() -> URL {
+        var components = URLComponents()
+        components.scheme = "https"
+        components.host = "api.github.com"
+        components.path = "/repos/zachyzissou/Oscillo/releases"
+        components.queryItems = [
+            URLQueryItem(name: "per_page", value: "20")
+        ]
+        return components.url!
     }
 }
 

--- a/native/Sources/OscilloMac/LiveAudioEngine.swift
+++ b/native/Sources/OscilloMac/LiveAudioEngine.swift
@@ -1,6 +1,4 @@
-import Accelerate
 import AVFoundation
-import Combine
 import OscilloCore
 import SwiftUI
 
@@ -22,6 +20,11 @@ final class LiveAudioEngine: ObservableObject {
 
     init(sceneSettingsStore: SceneSettingsStore = SceneSettingsStore()) {
         self.sceneSettingsStore = sceneSettingsStore
+    }
+
+    isolated deinit {
+        previewTimer?.invalidate()
+        publishTimer?.invalidate()
     }
 
     func startMicrophone() {
@@ -86,6 +89,8 @@ final class LiveAudioEngine: ObservableObject {
             features = .silence
             statusMessage = "Idle"
         }
+
+        stopPublishingIfIdle()
     }
 
     private func beginPublishing() {
@@ -97,6 +102,13 @@ final class LiveAudioEngine: ObservableObject {
                 self.features = self.featureStore.snapshot()
             }
         }
+    }
+
+    private func stopPublishingIfIdle() {
+        guard !isRunning, !isPreviewing else { return }
+
+        publishTimer?.invalidate()
+        publishTimer = nil
     }
 
     private func advancePreviewSignal() {

--- a/native/Sources/OscilloMac/LiveAudioEngine.swift
+++ b/native/Sources/OscilloMac/LiveAudioEngine.swift
@@ -123,9 +123,7 @@ final class LiveAudioEngine: ObservableObject {
 
         featureStore.update(AudioFeatures(
             volume: volume,
-            bassEnergy: bass,
-            midEnergy: mid,
-            trebleEnergy: treble,
+            bands: AudioEnergyBands(bass: bass, mid: mid, treble: treble),
             peakFrequency: 120 + mid * 2_800,
             spectralCentroid: 600 + treble * 7_500,
             rms: volume,

--- a/native/Sources/OscilloMac/LiveAudioEngine.swift
+++ b/native/Sources/OscilloMac/LiveAudioEngine.swift
@@ -1,0 +1,156 @@
+import Accelerate
+import AVFoundation
+import Combine
+import OscilloCore
+import SwiftUI
+
+@MainActor
+final class LiveAudioEngine: ObservableObject {
+    @Published private(set) var isRunning = false
+    @Published private(set) var isPreviewing = false
+    @Published private(set) var features = AudioFeatures.silence
+    @Published private(set) var statusMessage = "Preview signal"
+
+    let featureStore = AudioFeatureStore()
+
+    private let sceneSettingsStore: SceneSettingsStore
+    private let engine = AVAudioEngine()
+    private let processor = AudioProcessor()
+    private var previewTimer: Timer?
+    private var publishTimer: Timer?
+    private var previewPhase = Float(0)
+
+    init(sceneSettingsStore: SceneSettingsStore = SceneSettingsStore()) {
+        self.sceneSettingsStore = sceneSettingsStore
+    }
+
+    func startMicrophone() {
+        stopPreview(resetFeatures: false)
+
+        let input = engine.inputNode
+        input.removeTap(onBus: 0)
+
+        let format = input.outputFormat(forBus: 0)
+        let processor = processor
+        let featureStore = featureStore
+
+        input.installTap(onBus: 0, bufferSize: 1_024, format: format) { buffer, _ in
+            guard let features = processor.process(buffer: buffer) else {
+                return
+            }
+            featureStore.update(features)
+        }
+
+        do {
+            engine.prepare()
+            try engine.start()
+            isRunning = true
+            statusMessage = "Microphone input"
+            beginPublishing()
+        } catch {
+            input.removeTap(onBus: 0)
+            isRunning = false
+            statusMessage = "Microphone unavailable; using preview signal"
+            startPreview()
+        }
+    }
+
+    func stopMicrophone() {
+        engine.inputNode.removeTap(onBus: 0)
+        engine.stop()
+        isRunning = false
+        statusMessage = "Preview signal"
+        startPreview()
+    }
+
+    func startPreview() {
+        guard previewTimer == nil else { return }
+        isPreviewing = true
+        statusMessage = isRunning ? "Microphone input" : "Preview signal"
+        beginPublishing()
+
+        previewTimer = Timer.scheduledTimer(withTimeInterval: 1.0 / 60.0, repeats: true) { [weak self] _ in
+            Task { @MainActor in
+                self?.advancePreviewSignal()
+            }
+        }
+    }
+
+    func stopPreview(resetFeatures: Bool) {
+        previewTimer?.invalidate()
+        previewTimer = nil
+        isPreviewing = false
+
+        if resetFeatures, !isRunning {
+            featureStore.update(.silence)
+            features = .silence
+            statusMessage = "Idle"
+        }
+    }
+
+    private func beginPublishing() {
+        guard publishTimer == nil else { return }
+
+        publishTimer = Timer.scheduledTimer(withTimeInterval: 1.0 / 30.0, repeats: true) { [weak self] _ in
+            Task { @MainActor in
+                guard let self else { return }
+                self.features = self.featureStore.snapshot()
+            }
+        }
+    }
+
+    private func advancePreviewSignal() {
+        guard !isRunning else { return }
+
+        let settings = sceneSettingsStore.snapshot()
+        previewPhase += (1.0 / 60.0) * settings.previewTempo
+        let bass = normalizedWave(previewPhase * 0.7)
+        let mid = normalizedWave(previewPhase * 1.1 + 1.4) * 0.72
+        let treble = normalizedWave(previewPhase * 2.6 + 2.0) * 0.48
+        let volume = min(1, 0.28 + bass * 0.44 + treble * 0.18)
+
+        featureStore.update(AudioFeatures(
+            volume: volume,
+            bassEnergy: bass,
+            midEnergy: mid,
+            trebleEnergy: treble,
+            peakFrequency: 120 + mid * 2_800,
+            spectralCentroid: 600 + treble * 7_500,
+            rms: volume,
+            zeroCrossingRate: 0.04 + treble * 0.16
+        ))
+    }
+
+    private func normalizedWave(_ phase: Float) -> Float {
+        (sin(phase * 2 * .pi) + 1) * 0.5
+    }
+}
+
+private final class AudioProcessor: @unchecked Sendable {
+    private let sampleCount = 1_024
+    private let analyzer = VDSPFrequencyAnalyzer(sampleCount: 1_024)!
+
+    func process(buffer: AVAudioPCMBuffer) -> AudioFeatures? {
+        guard let channel = buffer.floatChannelData?[0] else {
+            return nil
+        }
+
+        let frameCount = min(Int(buffer.frameLength), sampleCount)
+        guard frameCount > 0 else {
+            return nil
+        }
+
+        var samples = Array(UnsafeBufferPointer(start: channel, count: frameCount))
+        if samples.count < sampleCount {
+            samples.append(contentsOf: repeatElement(0, count: sampleCount - samples.count))
+        }
+
+        let magnitudes = analyzer.magnitudes(for: samples)
+
+        return AudioFeatureExtractor.extract(
+            frequencyMagnitudes: magnitudes,
+            timeDomainSamples: samples,
+            sampleRate: Float(buffer.format.sampleRate)
+        )
+    }
+}

--- a/native/Sources/OscilloMac/MetalShaderSource.swift
+++ b/native/Sources/OscilloMac/MetalShaderSource.swift
@@ -1,0 +1,131 @@
+enum MetalShaderSource {
+    static let fullScreenTunnel = """
+    #include <metal_stdlib>
+    using namespace metal;
+
+    struct VertexOut {
+        float4 position [[position]];
+        float2 uv;
+    };
+
+    struct ShaderUniforms {
+        float time;
+        float audioLevel;
+        float bassEnergy;
+        float midEnergy;
+        float trebleEnergy;
+        float visualGain;
+        float particleDensity;
+        int paletteIndex;
+        float padding;
+        float2 resolution;
+    };
+
+    vertex VertexOut oscilloVertex(uint vertexID [[vertex_id]]) {
+        float2 positions[3] = {
+            float2(-1.0, -1.0),
+            float2( 3.0, -1.0),
+            float2(-1.0,  3.0)
+        };
+
+        VertexOut out;
+        out.position = float4(positions[vertexID], 0.0, 1.0);
+        out.uv = positions[vertexID] * 0.5 + 0.5;
+        return out;
+    }
+
+    static float hash21(float2 p) {
+        return fract(sin(dot(p, float2(127.1, 311.7))) * 43758.5453123);
+    }
+
+    static float3 paletteColor(int paletteIndex, int slot, float3 audio) {
+        if (paletteIndex == 1) {
+            float3 colors[3] = {
+                float3(0.02, 0.90, 0.76),
+                float3(0.42, 0.22, 1.00),
+                float3(0.88, 0.96, 1.00)
+            };
+            return colors[slot] + audio * 0.16;
+        }
+
+        if (paletteIndex == 2) {
+            float3 colors[3] = {
+                float3(1.00, 0.35, 0.08),
+                float3(1.00, 0.78, 0.18),
+                float3(0.52, 0.05, 0.02)
+            };
+            return colors[slot] + audio * 0.12;
+        }
+
+        if (paletteIndex == 3) {
+            float value = slot == 0 ? 0.24 : (slot == 1 ? 0.74 : 1.0);
+            return float3(value, value, value) + audio * 0.08;
+        }
+
+        float3 colors[3] = {
+            float3(0.02, 0.32, 1.00),
+            float3(1.00, 0.04, 0.46),
+            float3(0.36, 1.00, 0.58)
+        };
+        return colors[slot] + audio * 0.14;
+    }
+
+    static float noteOrb(float2 p, int index, float time, float audio, float density) {
+        float count = 12.0;
+        float t = float(index) / count;
+        float radius = 0.30 + sin(t * 12.56637) * 0.08;
+        float height = (t - 0.5) * 0.86;
+        float angle = t * 18.84955 + time * (0.18 + audio * 0.4);
+        float2 center = float2(cos(angle) * radius, height + sin(time * 0.8 + t * 6.0) * 0.04);
+        float d = length(p - center);
+        float size = (0.018 + 0.012 * density) * (1.0 + audio * 1.8);
+        return smoothstep(size, 0.0, d);
+    }
+
+    fragment half4 oscilloFragment(VertexOut in [[stage_in]],
+                                   constant ShaderUniforms &uniforms [[buffer(0)]]) {
+        float2 uv = in.uv;
+        float aspect = uniforms.resolution.x / max(uniforms.resolution.y, 1.0);
+        float2 p = (uv * 2.0 - 1.0) * float2(aspect, 1.0);
+        float radius = length(p);
+        float angle = atan2(p.y, p.x);
+
+        float audio = clamp(uniforms.audioLevel * uniforms.visualGain, 0.0, 1.0);
+        float density = clamp(uniforms.particleDensity, 0.15, 1.5);
+        float speed = 0.85 + audio * 2.0 + uniforms.trebleEnergy;
+        float tunnel = sin(log(radius + 0.08) * 18.0 - uniforms.time * speed + angle * 7.0);
+        float spokes = sin(angle * (10.0 + uniforms.midEnergy * 12.0) + uniforms.time);
+        float ring = smoothstep(0.13, 0.0, abs(tunnel + spokes * 0.18));
+        float glow = exp(-radius * (1.6 - uniforms.bassEnergy * 0.55));
+
+        float2 starCell = floor(uv * uniforms.resolution / 3.0);
+        float starSeed = hash21(starCell);
+        float star = step(0.996, starSeed) * (0.35 + 0.65 * sin(uniforms.time * 2.0 + starSeed * 6.28318));
+
+        float3 audioVector = float3(uniforms.bassEnergy, uniforms.midEnergy, uniforms.trebleEnergy);
+        float3 blue = paletteColor(uniforms.paletteIndex, 0, audioVector);
+        float3 pink = paletteColor(uniforms.paletteIndex, 1, audioVector);
+        float3 green = paletteColor(uniforms.paletteIndex, 2, audioVector);
+        float colorMix = 0.5 + 0.5 * sin(angle + uniforms.time * 0.22 + uniforms.bassEnergy * 2.4);
+
+        float3 color = mix(blue, pink, colorMix);
+        color = mix(color, green, uniforms.midEnergy * 0.35);
+        color *= 0.08 + ring * (0.75 + audio * 0.8) + glow * 0.34;
+        color += star * float3(0.42, 0.7, 1.0);
+        color += pow(max(0.0, 1.0 - radius), 3.0) * uniforms.bassEnergy * float3(0.5, 0.05, 0.18);
+
+        float orbMask = 0.0;
+        for (int i = 0; i < 12; i++) {
+            orbMask += noteOrb(p, i, uniforms.time, audio, density);
+        }
+        orbMask = clamp(orbMask, 0.0, 1.0);
+        color = mix(color, green * (1.1 + audio), orbMask);
+
+        float morphA = smoothstep(0.035 + audio * 0.04, 0.0, abs(length(p - float2(0.46, 0.18)) - 0.11 - sin(uniforms.time) * 0.03));
+        float morphB = smoothstep(0.03 + audio * 0.03, 0.0, abs(length(p - float2(-0.52, -0.22)) - 0.09 - cos(uniforms.time * 0.8) * 0.025));
+        color += (morphA * blue + morphB * pink) * (0.34 + audio * 0.4);
+
+        return half4(half3(color), 1.0);
+    }
+    """
+}

--- a/native/Sources/OscilloMac/OscilloMacApp.swift
+++ b/native/Sources/OscilloMac/OscilloMacApp.swift
@@ -1,0 +1,22 @@
+import OscilloCore
+import SwiftUI
+
+@main
+struct OscilloMacApp: App {
+    @StateObject private var audioEngine: LiveAudioEngine
+    @StateObject private var sceneController: SceneController
+
+    init() {
+        let settingsStore = SceneSettingsStore()
+        _audioEngine = StateObject(wrappedValue: LiveAudioEngine(sceneSettingsStore: settingsStore))
+        _sceneController = StateObject(wrappedValue: SceneController(settingsStore: settingsStore))
+    }
+
+    var body: some Scene {
+        WindowGroup("Oscillo") {
+            ContentView(audioEngine: audioEngine, sceneController: sceneController)
+                .frame(minWidth: 960, minHeight: 640)
+        }
+        .windowStyle(.hiddenTitleBar)
+    }
+}

--- a/native/Sources/OscilloMac/OscilloMetalSurface.swift
+++ b/native/Sources/OscilloMac/OscilloMetalSurface.swift
@@ -24,7 +24,7 @@ struct OscilloMetalSurface: NSViewRepresentable {
         return view
     }
 
-    func updateNSView(_ view: MTKView, context: Context) {
+    func updateNSView(_: MTKView, context: Context) {
         context.coordinator.isActive = isActive
     }
 }

--- a/native/Sources/OscilloMac/OscilloMetalSurface.swift
+++ b/native/Sources/OscilloMac/OscilloMetalSurface.swift
@@ -1,0 +1,30 @@
+import MetalKit
+import OscilloCore
+import SwiftUI
+
+struct OscilloMetalSurface: NSViewRepresentable {
+    let featureStore: AudioFeatureStore
+    let settingsStore: SceneSettingsStore
+    var isActive: Bool
+
+    func makeCoordinator() -> OscilloRenderer {
+        OscilloRenderer(featureStore: featureStore, settingsStore: settingsStore)
+    }
+
+    func makeNSView(context: Context) -> MTKView {
+        let view = MTKView()
+        view.device = MTLCreateSystemDefaultDevice()
+        view.colorPixelFormat = .bgra8Unorm
+        view.clearColor = MTLClearColor(red: 0, green: 0, blue: 0.07, alpha: 1)
+        view.preferredFramesPerSecond = 60
+        view.enableSetNeedsDisplay = false
+        view.isPaused = false
+        view.delegate = context.coordinator
+        context.coordinator.configure(view: view)
+        return view
+    }
+
+    func updateNSView(_ view: MTKView, context: Context) {
+        context.coordinator.isActive = isActive
+    }
+}

--- a/native/Sources/OscilloMac/OscilloRenderer.swift
+++ b/native/Sources/OscilloMac/OscilloRenderer.swift
@@ -1,0 +1,101 @@
+import MetalKit
+import OscilloCore
+import simd
+
+final class OscilloRenderer: NSObject, MTKViewDelegate {
+    var isActive = true
+
+    private let featureStore: AudioFeatureStore
+    private let settingsStore: SceneSettingsStore
+    private var commandQueue: MTLCommandQueue?
+    private var pipelineState: MTLRenderPipelineState?
+    private var startTime = CFAbsoluteTimeGetCurrent()
+
+    init(featureStore: AudioFeatureStore, settingsStore: SceneSettingsStore) {
+        self.featureStore = featureStore
+        self.settingsStore = settingsStore
+        super.init()
+    }
+
+    @MainActor
+    func configure(view: MTKView) {
+        guard let device = view.device else {
+            return
+        }
+
+        commandQueue = device.makeCommandQueue()
+
+        do {
+            let library = try device.makeLibrary(source: MetalShaderSource.fullScreenTunnel, options: nil)
+            let descriptor = MTLRenderPipelineDescriptor()
+            descriptor.vertexFunction = library.makeFunction(name: "oscilloVertex")
+            descriptor.fragmentFunction = library.makeFunction(name: "oscilloFragment")
+            descriptor.colorAttachments[0].pixelFormat = view.colorPixelFormat
+            pipelineState = try device.makeRenderPipelineState(descriptor: descriptor)
+        } catch {
+            assertionFailure("Failed to compile Oscillo Metal pipeline: \(error)")
+        }
+    }
+
+    func mtkView(_ view: MTKView, drawableSizeWillChange size: CGSize) {}
+
+    func draw(in view: MTKView) {
+        guard
+            let drawable = view.currentDrawable,
+            let descriptor = view.currentRenderPassDescriptor,
+            let commandQueue,
+            let pipelineState,
+            let commandBuffer = commandQueue.makeCommandBuffer(),
+            let encoder = commandBuffer.makeRenderCommandEncoder(descriptor: descriptor)
+        else {
+            return
+        }
+
+        var uniforms = makeUniforms(for: view.drawableSize)
+
+        encoder.setRenderPipelineState(pipelineState)
+        encoder.setFragmentBytes(
+            &uniforms,
+            length: MemoryLayout<ShaderUniforms>.stride,
+            index: 0
+        )
+        encoder.drawPrimitives(type: .triangle, vertexStart: 0, vertexCount: 3)
+        encoder.endEncoding()
+
+        commandBuffer.present(drawable)
+        commandBuffer.commit()
+    }
+
+    private func makeUniforms(for size: CGSize) -> ShaderUniforms {
+        let elapsed = Float(CFAbsoluteTimeGetCurrent() - startTime)
+        let features = isActive ? featureStore.snapshot() : .silence
+        let settings = settingsStore.snapshot()
+        let level = min(1, max(features.volume, (features.bassEnergy + features.midEnergy + features.trebleEnergy) / 3))
+
+        return ShaderUniforms(
+            time: elapsed,
+            audioLevel: level,
+            bassEnergy: features.bassEnergy,
+            midEnergy: features.midEnergy,
+            trebleEnergy: features.trebleEnergy,
+            visualGain: settings.visualGain,
+            particleDensity: settings.particleDensity,
+            paletteIndex: settings.palette.uniformIndex,
+            padding: 0,
+            resolution: SIMD2<Float>(Float(max(size.width, 1)), Float(max(size.height, 1)))
+        )
+    }
+}
+
+private struct ShaderUniforms {
+    var time: Float
+    var audioLevel: Float
+    var bassEnergy: Float
+    var midEnergy: Float
+    var trebleEnergy: Float
+    var visualGain: Float
+    var particleDensity: Float
+    var paletteIndex: Int32
+    var padding: Float
+    var resolution: SIMD2<Float>
+}

--- a/native/Sources/OscilloMac/OscilloRenderer.swift
+++ b/native/Sources/OscilloMac/OscilloRenderer.swift
@@ -37,7 +37,9 @@ final class OscilloRenderer: NSObject, MTKViewDelegate {
         }
     }
 
-    func mtkView(_ view: MTKView, drawableSizeWillChange size: CGSize) {}
+    func mtkView(_: MTKView, drawableSizeWillChange _: CGSize) {
+        // The renderer reads drawableSize each frame when building shader uniforms.
+    }
 
     func draw(in view: MTKView) {
         guard

--- a/native/Sources/OscilloMac/SceneController.swift
+++ b/native/Sources/OscilloMac/SceneController.swift
@@ -1,0 +1,66 @@
+import OscilloCore
+import SwiftUI
+
+@MainActor
+final class SceneController: ObservableObject {
+    @Published private(set) var settings: SceneSettings
+
+    let settingsStore: SceneSettingsStore
+
+    init(settingsStore: SceneSettingsStore = SceneSettingsStore()) {
+        self.settingsStore = settingsStore
+        self.settings = settingsStore.snapshot()
+    }
+
+    func setVisualGain(_ value: Float) {
+        update(
+            visualGain: value,
+            particleDensity: settings.particleDensity,
+            previewTempo: settings.previewTempo,
+            palette: settings.palette
+        )
+    }
+
+    func setParticleDensity(_ value: Float) {
+        update(
+            visualGain: settings.visualGain,
+            particleDensity: value,
+            previewTempo: settings.previewTempo,
+            palette: settings.palette
+        )
+    }
+
+    func setPreviewTempo(_ value: Float) {
+        update(
+            visualGain: settings.visualGain,
+            particleDensity: settings.particleDensity,
+            previewTempo: value,
+            palette: settings.palette
+        )
+    }
+
+    func setPalette(_ palette: ScenePalette) {
+        update(
+            visualGain: settings.visualGain,
+            particleDensity: settings.particleDensity,
+            previewTempo: settings.previewTempo,
+            palette: palette
+        )
+    }
+
+    private func update(
+        visualGain: Float,
+        particleDensity: Float,
+        previewTempo: Float,
+        palette: ScenePalette
+    ) {
+        let next = SceneSettings(
+            visualGain: visualGain,
+            particleDensity: particleDensity,
+            previewTempo: previewTempo,
+            palette: palette
+        )
+        settings = next
+        settingsStore.update(next)
+    }
+}

--- a/native/Sources/OscilloMac/UpdateController.swift
+++ b/native/Sources/OscilloMac/UpdateController.swift
@@ -1,0 +1,58 @@
+import AppKit
+import Foundation
+import OscilloCore
+
+@MainActor
+final class UpdateController: ObservableObject {
+    @Published private(set) var isChecking = false
+    @Published private(set) var statusText = "No update check yet."
+    @Published private(set) var releaseURL: URL?
+
+    private let service: GitHubUpdateService
+
+    init(service: GitHubUpdateService = GitHubUpdateService()) {
+        self.service = service
+    }
+
+    func checkNow() {
+        guard !isChecking else { return }
+
+        isChecking = true
+        statusText = "Checking GitHub Releases..."
+        releaseURL = nil
+
+        Task {
+            defer { isChecking = false }
+
+            do {
+                let result = try await service.checkForUpdates(
+                    currentVersionString: Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String ?? "0.1.0"
+                )
+                apply(result)
+            } catch {
+                statusText = "Update check failed: \(error.localizedDescription)"
+            }
+        }
+    }
+
+    func openReleasePage() {
+        guard let releaseURL else { return }
+        NSWorkspace.shared.open(releaseURL)
+    }
+
+    private func apply(_ result: UpdateCheckResult) {
+        switch result {
+        case .noRelease:
+            statusText = "No native release has been published yet."
+        case .current:
+            statusText = "You are running the latest published native build."
+        case .updateAvailable(let update):
+            releaseURL = update.releaseURL
+            if update.downloadURL != nil {
+                statusText = "Update \(update.tagName) is available."
+            } else {
+                statusText = "Update \(update.tagName) is available, but no macOS zip asset was found."
+            }
+        }
+    }
+}

--- a/native/Tests/OscilloCoreTests/AppBundleMetadataTests.swift
+++ b/native/Tests/OscilloCoreTests/AppBundleMetadataTests.swift
@@ -1,0 +1,46 @@
+import Foundation
+import XCTest
+
+final class AppBundleMetadataTests: XCTestCase {
+    func testInfoPlistDeclaresMacAppAndMicrophoneUsage() throws {
+        let plistURL = packageRoot()
+            .appendingPathComponent("AppBundle")
+            .appendingPathComponent("Info.plist")
+        let data = try Data(contentsOf: plistURL)
+        let plist = try XCTUnwrap(
+            PropertyListSerialization.propertyList(from: data, options: [], format: nil)
+                as? [String: Any]
+        )
+
+        XCTAssertEqual(plist["CFBundleExecutable"] as? String, "OscilloMac")
+        XCTAssertEqual(plist["CFBundlePackageType"] as? String, "APPL")
+        XCTAssertEqual(plist["CFBundleIdentifier"] as? String, "com.zachyzissou.oscillo.native.mac")
+        XCTAssertEqual(
+            plist["NSMicrophoneUsageDescription"] as? String,
+            "Oscillo uses microphone input to drive real-time audio-reactive visuals."
+        )
+    }
+
+    func testEntitlementsAllowSandboxedAudioInput() throws {
+        let plistURL = packageRoot()
+            .appendingPathComponent("AppBundle")
+            .appendingPathComponent("OscilloMac.entitlements")
+        let data = try Data(contentsOf: plistURL)
+        let plist = try XCTUnwrap(
+            PropertyListSerialization.propertyList(from: data, options: [], format: nil)
+                as? [String: Any]
+        )
+
+        XCTAssertEqual(plist["com.apple.security.app-sandbox"] as? Bool, true)
+        XCTAssertEqual(plist["com.apple.security.device.audio-input"] as? Bool, true)
+        XCTAssertEqual(plist["com.apple.security.network.client"] as? Bool, true)
+    }
+
+    private func packageRoot() -> URL {
+        var url = URL(fileURLWithPath: #filePath)
+        while url.lastPathComponent != "native" {
+            url.deleteLastPathComponent()
+        }
+        return url
+    }
+}

--- a/native/Tests/OscilloCoreTests/AppVersionTests.swift
+++ b/native/Tests/OscilloCoreTests/AppVersionTests.swift
@@ -1,0 +1,23 @@
+import XCTest
+@testable import OscilloCore
+
+final class AppVersionTests: XCTestCase {
+    func testParsesNativeReleaseTags() throws {
+        let version = try XCTUnwrap(AppVersion("native-v1.2.3"))
+
+        XCTAssertEqual(version.major, 1)
+        XCTAssertEqual(version.minor, 2)
+        XCTAssertEqual(version.patch, 3)
+    }
+
+    func testComparesSemanticVersions() throws {
+        XCTAssertTrue(try XCTUnwrap(AppVersion("0.2.0")) > XCTUnwrap(AppVersion("0.1.9")))
+        XCTAssertTrue(try XCTUnwrap(AppVersion("1.0.0")) > XCTUnwrap(AppVersion("0.9.9")))
+        XCTAssertFalse(try XCTUnwrap(AppVersion("0.1.0")) > XCTUnwrap(AppVersion("0.1.0")))
+    }
+
+    func testRejectsInvalidVersions() {
+        XCTAssertNil(AppVersion("release-candidate"))
+        XCTAssertNil(AppVersion("1.2"))
+    }
+}

--- a/native/Tests/OscilloCoreTests/AppVersionTests.swift
+++ b/native/Tests/OscilloCoreTests/AppVersionTests.swift
@@ -13,7 +13,10 @@ final class AppVersionTests: XCTestCase {
     func testComparesSemanticVersions() throws {
         XCTAssertTrue(try XCTUnwrap(AppVersion("0.2.0")) > XCTUnwrap(AppVersion("0.1.9")))
         XCTAssertTrue(try XCTUnwrap(AppVersion("1.0.0")) > XCTUnwrap(AppVersion("0.9.9")))
-        XCTAssertFalse(try XCTUnwrap(AppVersion("0.1.0")) > XCTUnwrap(AppVersion("0.1.0")))
+
+        let version = try XCTUnwrap(AppVersion("0.1.0"))
+        let sameVersion = try XCTUnwrap(AppVersion("0.1.0"))
+        XCTAssertFalse(version > sameVersion)
     }
 
     func testRejectsInvalidVersions() {

--- a/native/Tests/OscilloCoreTests/AudioFeatureExtractorTests.swift
+++ b/native/Tests/OscilloCoreTests/AudioFeatureExtractorTests.swift
@@ -1,0 +1,32 @@
+import XCTest
+@testable import OscilloCore
+
+final class AudioFeatureExtractorTests: XCTestCase {
+    func testExtractsEnergyBandsAndPeakFrequency() {
+        var magnitudes = Array(repeating: Float(0), count: 1_024)
+        magnitudes[10] = 1.0
+        magnitudes[100] = 0.5
+        magnitudes[500] = 0.25
+
+        let features = AudioFeatureExtractor.extract(
+            frequencyMagnitudes: magnitudes,
+            timeDomainSamples: Array(repeating: 0, count: 1_024),
+            sampleRate: 44_100
+        )
+
+        XCTAssertGreaterThan(features.bassEnergy, features.midEnergy)
+        XCTAssertGreaterThan(features.midEnergy, features.trebleEnergy)
+        XCTAssertEqual(features.peakFrequency, 215.33, accuracy: 22.0)
+    }
+
+    func testComputesRMSAndZeroCrossingRate() {
+        let features = AudioFeatureExtractor.extract(
+            frequencyMagnitudes: Array(repeating: 0, count: 8),
+            timeDomainSamples: [-1, 1, -1, 1],
+            sampleRate: 44_100
+        )
+
+        XCTAssertEqual(features.rms, 1.0, accuracy: 0.0001)
+        XCTAssertEqual(features.zeroCrossingRate, 0.75, accuracy: 0.0001)
+    }
+}

--- a/native/Tests/OscilloCoreTests/NativeReleaseSelectorTests.swift
+++ b/native/Tests/OscilloCoreTests/NativeReleaseSelectorTests.swift
@@ -1,0 +1,24 @@
+import XCTest
+@testable import OscilloCore
+
+final class NativeReleaseSelectorTests: XCTestCase {
+    func testSelectsNewestNativeReleaseTag() throws {
+        let release = try XCTUnwrap(NativeReleaseSelector.newest(in: [
+            "v9.9.9",
+            "native-v0.1.1",
+            "native-v0.1.3",
+            "native-v0.1.2"
+        ]))
+
+        XCTAssertEqual(release.tagName, "native-v0.1.3")
+        XCTAssertEqual(release.version, AppVersion("0.1.3"))
+    }
+
+    func testIgnoresNonNativeReleaseTags() {
+        XCTAssertNil(NativeReleaseSelector.newest(in: [
+            "v1.0.0",
+            "web-v2.0.0",
+            "release-candidate"
+        ]))
+    }
+}

--- a/native/Tests/OscilloCoreTests/NoteFieldTests.swift
+++ b/native/Tests/OscilloCoreTests/NoteFieldTests.swift
@@ -1,0 +1,26 @@
+import XCTest
+@testable import OscilloCore
+
+final class NoteFieldTests: XCTestCase {
+    func testGeneratesDeterministicSpiralNotes() {
+        let notes = ["C4", "D4", "E4", "F4", "G4", "A4", "B4", "C5"]
+        let field = NoteField.generate(scaleNotes: notes)
+
+        XCTAssertEqual(field.count, notes.count)
+        XCTAssertEqual(field[0].note, "C4")
+        XCTAssertEqual(field[0].kind, .chord)
+        XCTAssertEqual(field[1].kind, .note)
+        XCTAssertEqual(field[3].kind, .beat)
+        XCTAssertEqual(field[0].position.x, 6.0, accuracy: 0.0001)
+        XCTAssertEqual(field[0].position.y, -4.0, accuracy: 0.0001)
+        XCTAssertEqual(field[0].position.z, 0.0, accuracy: 0.0001)
+    }
+
+    func testLimitsSpiralToTwelveNotes() {
+        let notes = (0..<24).map { "N\($0)" }
+        let field = NoteField.generate(scaleNotes: notes)
+
+        XCTAssertEqual(field.count, 12)
+        XCTAssertEqual(field.last?.note, "N11")
+    }
+}

--- a/native/Tests/OscilloCoreTests/QualityProfileTests.swift
+++ b/native/Tests/OscilloCoreTests/QualityProfileTests.swift
@@ -1,0 +1,11 @@
+import XCTest
+@testable import OscilloCore
+
+final class QualityProfileTests: XCTestCase {
+    func testProfilesMatchNativePerformanceTiers() {
+        XCTAssertEqual(QualityProfile.low.starCountScale, 0.4)
+        XCTAssertFalse(QualityProfile.low.shadowsEnabled)
+        XCTAssertTrue(QualityProfile.medium.postProcessingEnabled)
+        XCTAssertEqual(QualityProfile.high.particleScale, 1.0)
+    }
+}

--- a/native/Tests/OscilloCoreTests/SceneSettingsTests.swift
+++ b/native/Tests/OscilloCoreTests/SceneSettingsTests.swift
@@ -1,0 +1,42 @@
+import XCTest
+@testable import OscilloCore
+
+final class SceneSettingsTests: XCTestCase {
+    func testClampsInteractiveControlsToSupportedRanges() {
+        let settings = SceneSettings(
+            visualGain: 4.5,
+            particleDensity: -2,
+            previewTempo: 4,
+            palette: .solar
+        )
+
+        XCTAssertEqual(settings.visualGain, 2.0)
+        XCTAssertEqual(settings.particleDensity, 0.15)
+        XCTAssertEqual(settings.previewTempo, 2.0)
+        XCTAssertEqual(settings.palette, .solar)
+    }
+
+    func testStorePublishesThreadSafeSnapshots() {
+        let store = SceneSettingsStore()
+        store.update(SceneSettings(
+            visualGain: 0.5,
+            particleDensity: 0.8,
+            previewTempo: 1.25,
+            palette: .aurora
+        ))
+
+        let snapshot = store.snapshot()
+
+        XCTAssertEqual(snapshot.visualGain, 0.5)
+        XCTAssertEqual(snapshot.particleDensity, 0.8)
+        XCTAssertEqual(snapshot.previewTempo, 1.25)
+        XCTAssertEqual(snapshot.palette, .aurora)
+    }
+
+    func testPaletteIndexIsStableForMetalUniforms() {
+        XCTAssertEqual(ScenePalette.neon.uniformIndex, 0)
+        XCTAssertEqual(ScenePalette.aurora.uniformIndex, 1)
+        XCTAssertEqual(ScenePalette.solar.uniformIndex, 2)
+        XCTAssertEqual(ScenePalette.mono.uniformIndex, 3)
+    }
+}

--- a/native/Tests/OscilloCoreTests/VDSPFrequencyAnalyzerTests.swift
+++ b/native/Tests/OscilloCoreTests/VDSPFrequencyAnalyzerTests.swift
@@ -1,0 +1,33 @@
+import XCTest
+@testable import OscilloCore
+
+final class VDSPFrequencyAnalyzerTests: XCTestCase {
+    func testDetectsPeakFrequencyForSineWave() throws {
+        let sampleRate: Float = 44_100
+        let sampleCount = 2_048
+        let targetFrequency: Float = 440
+        let analyzer = try XCTUnwrap(VDSPFrequencyAnalyzer(sampleCount: sampleCount))
+        let samples = (0..<sampleCount).map { index in
+            sin(2 * Float.pi * targetFrequency * Float(index) / sampleRate)
+        }
+
+        let magnitudes = analyzer.magnitudes(for: samples)
+        let features = AudioFeatureExtractor.extract(
+            frequencyMagnitudes: magnitudes,
+            timeDomainSamples: samples,
+            sampleRate: sampleRate
+        )
+
+        XCTAssertEqual(magnitudes.count, sampleCount / 2)
+        XCTAssertEqual(features.peakFrequency, targetFrequency, accuracy: 24)
+        XCTAssertGreaterThan(features.midEnergy, features.bassEnergy)
+    }
+
+    func testPadsShortInputToConfiguredSize() throws {
+        let analyzer = try XCTUnwrap(VDSPFrequencyAnalyzer(sampleCount: 1_024))
+
+        let magnitudes = analyzer.magnitudes(for: [0, 0.5, -0.5, 0])
+
+        XCTAssertEqual(magnitudes.count, 512)
+    }
+}

--- a/native/UPDATES.md
+++ b/native/UPDATES.md
@@ -1,0 +1,48 @@
+# Native Update Channel
+
+Oscillo now has the first GitHub-backed native update lane.
+
+## Current Behavior
+
+- `native/dist/Oscillo.app` is a local signed macOS app bundle.
+- The app includes a visible `Check Updates` control.
+- The update check calls GitHub Releases for `zachyzissou/Oscillo`.
+- If a newer `native-vX.Y.Z` release exists, the app enables an `Open Release` button.
+- Release builds publish a macOS zip asset and `oscillo-native-update.json` manifest.
+
+This is enough for test builds on a MacBook Pro without pretending we have secure self-replacement yet.
+
+## Release Flow
+
+Manual release:
+
+```bash
+gh workflow run "Native macOS Release" --repo zachyzissou/Oscillo -f tag=native-v0.1.0
+```
+
+Tag release:
+
+```bash
+git tag native-v0.1.0
+git push origin native-v0.1.0
+```
+
+Both paths build and publish:
+
+- `Oscillo-macOS-<version>.zip`
+- `Oscillo-macOS-<version>.zip.sha256`
+- `oscillo-native-update.json`
+
+## Secure OTA Install Path
+
+For automatic in-app download/install, use Sparkle 2 once the project has a full Xcode app target and signing secrets.
+
+Required future work:
+
+- Add Sparkle as a Swift package or embedded framework in the Xcode app target.
+- Generate and protect Sparkle EdDSA private key outside the repo.
+- Add the Sparkle public key and appcast URL to app metadata.
+- Use Developer ID signing and notarization for public MacBook installs.
+- Publish Sparkle appcast assets from the native release workflow.
+
+Sparkle is the right self-update mechanism for direct-distributed macOS apps. The current GitHub release check is the safe interim step.


### PR DESCRIPTION
## Summary
Adds the native macOS lane for Oscillo and moves it into GitHub workflow:

- SwiftPM `native/` package with `OscilloCore` and `OscilloMac`
- Launchable locally signed `native/dist/Oscillo.app` build script
- Native macOS GitHub Actions CI on `macos-26`
- Native release workflow that publishes macOS zip/checksum/update manifest assets
- In-app GitHub Releases update check surface
- Native issue templates and PR checklist items
- Update-channel docs with the secure Sparkle OTA path

## Type of change
- [x] CI / automation
- [x] Native macOS
- [x] Native release/update channel
- [x] Docs / README

## Validation
- [x] Native: `DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer swift test` -> 15 tests, 0 failures
- [x] Native: `DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer ./Scripts/build-macos-app.sh` -> built and signed `native/dist/Oscillo.app`
- [x] Native: `DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer ./Scripts/run-macos-app.sh` -> app launched and `OscilloMac` process observed
- [x] CI config: Ruby YAML parse for native workflows and issue forms

## Related issues
Refs native macOS pipeline/update lane.

## Notes
This establishes GitHub Releases as the initial update channel. Secure automatic install should be done through Sparkle 2 after adding a full Xcode app target plus Developer ID signing/notarization secrets.
