### PR TITLE
chore(native): bump mac app version to 0.1.1

### DIFF
--- a/native/AppBundle/Info.plist
+++ b/native/AppBundle/Info.plist
@@ -17,9 +17,9 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>0.1.0</string>
+	<string>0.1.1</string>
 	<key>CFBundleVersion</key>
-	<string>1</string>
+	<string>2</string>
 	<key>LSApplicationCategoryType</key>
 	<string>public.app-category.music</string>
 	<key>LSMinimumSystemVersion</key>

--- a/native/Sources/OscilloMac/UpdateController.swift
+++ b/native/Sources/OscilloMac/UpdateController.swift
@@ -26,7 +26,7 @@ final class UpdateController: ObservableObject {
 
             do {
                 let result = try await service.checkForUpdates(
-                    currentVersionString: Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String ?? "0.1.0"
+                    currentVersionString: Self.bundleShortVersion
                 )
                 apply(result)
             } catch {
@@ -38,6 +38,10 @@ final class UpdateController: ObservableObject {
     func openReleasePage() {
         guard let releaseURL else { return }
         NSWorkspace.shared.open(releaseURL)
+    }
+
+    private static var bundleShortVersion: String {
+        Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String ?? ""
     }
 
     private func apply(_ result: UpdateCheckResult) {

--- a/native/Tests/OscilloCoreTests/AppBundleMetadataTests.swift
+++ b/native/Tests/OscilloCoreTests/AppBundleMetadataTests.swift
@@ -15,6 +15,8 @@ final class AppBundleMetadataTests: XCTestCase {
         XCTAssertEqual(plist["CFBundleExecutable"] as? String, "OscilloMac")
         XCTAssertEqual(plist["CFBundlePackageType"] as? String, "APPL")
         XCTAssertEqual(plist["CFBundleIdentifier"] as? String, "com.zachyzissou.oscillo.native.mac")
+        XCTAssertEqual(plist["CFBundleShortVersionString"] as? String, "0.1.1")
+        XCTAssertEqual(plist["CFBundleVersion"] as? String, "2")
         XCTAssertEqual(
             plist["NSMicrophoneUsageDescription"] as? String,
             "Oscillo uses microphone input to drive real-time audio-reactive visuals."


### PR DESCRIPTION
## Summary
- bump native macOS bundle version to 0.1.1 / build 2
- assert the bundle version in metadata tests so release tags do not drift from the app bundle

## Validation
- `DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer swift test`
- `plutil -lint native/AppBundle/Info.plist`
- `DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer ./Scripts/build-macos-app.sh`
- `codesign --verify --deep --strict native/dist/Oscillo.app`

After this merges, cut tag `native-v0.1.1` to publish the next GitHub Release build.