### PR TITLE
ci: update GitHub Actions runtime majors

### DIFF
--- a/.github/workflows/baseline-ts-ci.yml
+++ b/.github/workflows/baseline-ts-ci.yml
@@ -10,8 +10,8 @@ jobs:
   baseline-ts:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@v6.0.2
+      - uses: actions/setup-node@v6.4.0
         with:
           node-version: '22'
       - name: Install dependencies

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,9 +11,9 @@ jobs:
     outputs:
       web: ${{ steps.filter.outputs.web }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6.0.2
       - id: filter
-        uses: dorny/paths-filter@6852f92c20ea7fd3b0c25de3b5112db3a98da050
+        uses: dorny/paths-filter@fbd0ab8f3e69293af611ebaee6363fc25e6d187d
         with:
           filters: |
             web:
@@ -40,8 +40,8 @@ jobs:
     needs: changes
     if: needs.changes.outputs.web == 'true'
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@v6.0.2
+      - uses: actions/setup-node@v6.4.0
         with:
           node-version: 20
           cache: 'npm'
@@ -52,7 +52,7 @@ jobs:
       - run: npm run build
       - name: Upload build artifacts
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7.0.1
         with:
           name: build-files
           path: .next
@@ -73,8 +73,8 @@ jobs:
     env:
       SECURITY_AUDIT_LEVEL: ${{ vars.SECURITY_AUDIT_LEVEL }}
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@v6.0.2
+      - uses: actions/setup-node@v6.4.0
         with:
           node-version: 20
           cache: 'npm'
@@ -98,7 +98,7 @@ jobs:
           node -e "const fs=require('fs');const p='security-audit-report.json';let raw='';try{raw=fs.readFileSync(p,'utf8');}catch(e){console.error('Error reading security-audit-report.json:',e.message);process.exit(1);}if(!raw||!raw.trim()){console.error('security-audit-report.json is empty or only whitespace.');process.exit(1);}let parsed;try{parsed=JSON.parse(raw);}catch(e){console.error('Failed to parse security-audit-report.json as JSON:',e.message);console.error('Raw content of security-audit-report.json:');console.error(raw);process.exit(1);}const v=(parsed.metadata&&parsed.metadata.vulnerabilities)||{};console.log('vulnerabilities:',JSON.stringify(v));"
       - name: Upload security audit report
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7.0.1
         with:
           name: security-audit-report
           path: security-audit-report.json
@@ -110,14 +110,14 @@ jobs:
     if: needs.changes.outputs.web == 'true' && github.ref == 'refs/heads/staging'
     needs: [changes, quick-checks]
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@v6.0.2
+      - uses: actions/setup-node@v6.4.0
         with:
           node-version: 20
           cache: 'npm'
       - run: npm ci
       - name: Download build artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8.0.1
         with:
           name: build-files
           path: .next
@@ -125,7 +125,7 @@ jobs:
       - name: List downloaded build
         run: ls -al .next | head
       - name: Cache Playwright browsers
-        uses: actions/cache@v4
+        uses: actions/cache@v5.0.5
         with:
           path: ~/.cache/ms-playwright
           key: ${{ runner.os }}-playwright-${{ hashFiles('package-lock.json') }}
@@ -147,14 +147,14 @@ jobs:
           CI: true
           RUN_VISUAL_REGRESSION: '1'
       - name: Upload test results
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7.0.1
         if: always()
         with:
           name: playwright-report
           path: playwright-report/
           retention-days: 30
       - name: Upload test videos
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7.0.1
         if: always()
         with:
           name: test-videos
@@ -166,8 +166,8 @@ jobs:
     needs: [changes, quick-checks]
     if: needs.changes.outputs.web == 'true' && (github.ref == 'refs/heads/main' || github.event_name == 'pull_request')
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@v6.0.2
+      - uses: actions/setup-node@v6.4.0
         with:
           node-version: 20
           cache: 'npm'
@@ -180,14 +180,14 @@ jobs:
           CI: true
           RUN_VISUAL_REGRESSION: '1'
       - name: Upload visual report
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7.0.1
         if: always()
         with:
           name: visual-playwright-report
           path: playwright-report/
           retention-days: 14
       - name: Upload visual failures
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7.0.1
         if: failure()
         with:
           name: visual-test-results

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -24,16 +24,16 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6.0.2
 
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@v3
+      uses: github/codeql-action/init@v4
       with:
         languages: ${{ matrix.language }}
         queries: security-and-quality
 
     - name: Setup Node.js
-      uses: actions/setup-node@v4
+      uses: actions/setup-node@v6.4.0
       with:
         node-version: '20'
         cache: 'npm'
@@ -45,6 +45,6 @@ jobs:
       run: npm run build
 
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@v3
+      uses: github/codeql-action/analyze@v4
       with:
         category: "/language:${{matrix.language}}"

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -19,13 +19,13 @@ jobs:
 
     steps:
       - name: 🧾 Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6.0.2
         with:
           fetch-depth: 0
 
       - name: Determine changed paths
         id: changes
-        uses: dorny/paths-filter@v3
+        uses: dorny/paths-filter@fbd0ab8f3e69293af611ebaee6363fc25e6d187d
         with:
           filters: |
             src:
@@ -51,7 +51,7 @@ jobs:
           echo "✅ Early cleanup completed"
 
       - name: 🔄 Restore Next.js cache
-        uses: actions/cache@v3
+        uses: actions/cache@v5.0.5
         with:
           path: .next/cache
           key: ${{ runner.os }}-nextjs-${{ hashFiles('package-lock.json') }}
@@ -60,13 +60,13 @@ jobs:
 
       - name: 🔧 Set up Node.js
         if: steps.changes.outputs.src == 'true'
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6.4.0
         with:
           node-version: 20
 
       - name: 📦 Cache npm
         if: steps.changes.outputs.src == 'true'
-        uses: actions/cache@v3
+        uses: actions/cache@v5.0.5
         with:
           path: ~/.npm
           key: ${{ runner.os }}-npm-${{ hashFiles('**/package-lock.json') }}
@@ -83,7 +83,7 @@ jobs:
 
       - name: 🛠 Set up Docker Buildx
         if: steps.changes.outputs.src == 'true'
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd
         with:
           driver: docker-container
 

--- a/.github/workflows/native-macos.yml
+++ b/.github/workflows/native-macos.yml
@@ -24,7 +24,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6.0.2
 
       - name: Toolchain
         run: |
@@ -52,7 +52,7 @@ jobs:
           shasum -a 256 dist/Oscillo-macOS-ci.zip | tee dist/Oscillo-macOS-ci.zip.sha256
 
       - name: Upload native app artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7.0.1
         with:
           name: Oscillo-macOS-ci
           path: |

--- a/.github/workflows/native-release.yml
+++ b/.github/workflows/native-release.yml
@@ -22,7 +22,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6.0.2
 
       - name: Resolve release metadata
         id: meta

--- a/.github/workflows/paths-filter.yml
+++ b/.github/workflows/paths-filter.yml
@@ -10,13 +10,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6.0.2
         with:
           fetch-depth: 0
 
       - name: Filter changes
         id: filter
-        uses: dorny/paths-filter@v3
+        uses: dorny/paths-filter@fbd0ab8f3e69293af611ebaee6363fc25e6d187d
         with:
           filters: |
             frontend:

--- a/.github/workflows/publish-ghcr.yml
+++ b/.github/workflows/publish-ghcr.yml
@@ -17,10 +17,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6.0.2
 
       - name: Set up Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6.4.0
         with:
           node-version: "20"
           cache: 'npm'
@@ -40,14 +40,14 @@ jobs:
         run: npm run test:smoke
 
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
+        uses: docker/setup-qemu-action@ce360397dd3f832beb865e1373c09c0e9f86d70a
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd
 
       - name: Extract metadata
         id: meta
-        uses: docker/metadata-action@v5
+        uses: docker/metadata-action@030e881283bb7a6894de51c315a6bfe6a94e05cf
         with:
           images: ${{ env.IMAGE_NAME }}
           tags: |
@@ -64,14 +64,14 @@ jobs:
             org.opencontainers.image.documentation=${{ github.server_url }}/${{ github.repository }}/blob/main/README.md
 
       - name: Login to GitHub Container Registry
-        uses: docker/login-action@v3
+        uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build and push Docker image
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@bcafcacb16a39f128d818304e6c9c0c18556b85f
         with:
           context: .
           platforms: linux/amd64,linux/arm64


### PR DESCRIPTION
## Summary
- update GitHub-owned actions to current Node-24-era release tags: checkout v6.0.2, setup-node v6.4.0, upload-artifact v7.0.1, download-artifact v8.0.1, cache v5.0.5, CodeQL v4
- update dorny/paths-filter to v4.0.1 and pin it to the resolved full commit SHA
- update Docker workflow actions to current major versions and pin third-party Docker actions to full commit SHAs

## Validation
- verified latest action releases via GitHub API / git refs
- parsed every `.github/workflows/*.yml` with Ruby YAML loader
- `git diff --check`

This proactively addresses the Node 20 action-runtime deprecation warning seen on the native release workflow.