### PR TITLE
Add native launch update checks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,7 @@ package-lock.json
 .buildcache/*
 !.buildcache/.gitkeep
 native/.build/
+native/.swiftpm/
 native/dist/
 tsconfig.tsbuildinfo
 

--- a/native/Sources/OscilloCore/LaunchUpdateCheckPolicy.swift
+++ b/native/Sources/OscilloCore/LaunchUpdateCheckPolicy.swift
@@ -1,0 +1,14 @@
+public struct LaunchUpdateCheckPolicy: Sendable {
+    private var hasStartedAutomaticCheck = false
+
+    public init() {}
+
+    public mutating func shouldStartAutomaticCheck() -> Bool {
+        guard !hasStartedAutomaticCheck else {
+            return false
+        }
+
+        hasStartedAutomaticCheck = true
+        return true
+    }
+}

--- a/native/Sources/OscilloMac/ContentView.swift
+++ b/native/Sources/OscilloMac/ContentView.swift
@@ -24,6 +24,7 @@ struct ContentView: View {
         }
         .task {
             audioEngine.startPreview()
+            updateController.checkAutomaticallyOnLaunch()
         }
     }
 }

--- a/native/Sources/OscilloMac/UpdateController.swift
+++ b/native/Sources/OscilloMac/UpdateController.swift
@@ -9,16 +9,35 @@ final class UpdateController: ObservableObject {
     @Published private(set) var releaseURL: URL?
 
     private let service: GitHubUpdateService
+    private var launchUpdateCheckPolicy = LaunchUpdateCheckPolicy()
 
     init(service: GitHubUpdateService = GitHubUpdateService()) {
         self.service = service
     }
 
     func checkNow() {
+        startCheck(
+            statusText: "Checking GitHub Releases...",
+            failurePrefix: "Update check failed"
+        )
+    }
+
+    func checkAutomaticallyOnLaunch() {
+        guard launchUpdateCheckPolicy.shouldStartAutomaticCheck() else {
+            return
+        }
+
+        startCheck(
+            statusText: "Checking for updates...",
+            failurePrefix: "Automatic update check failed"
+        )
+    }
+
+    private func startCheck(statusText: String, failurePrefix: String) {
         guard !isChecking else { return }
 
         isChecking = true
-        statusText = "Checking GitHub Releases..."
+        self.statusText = statusText
         releaseURL = nil
 
         Task {
@@ -30,7 +49,7 @@ final class UpdateController: ObservableObject {
                 )
                 apply(result)
             } catch {
-                statusText = "Update check failed: \(error.localizedDescription)"
+                self.statusText = "\(failurePrefix): \(error.localizedDescription)"
             }
         }
     }

--- a/native/Tests/OscilloCoreTests/LaunchUpdateCheckPolicyTests.swift
+++ b/native/Tests/OscilloCoreTests/LaunchUpdateCheckPolicyTests.swift
@@ -1,0 +1,11 @@
+import XCTest
+@testable import OscilloCore
+
+final class LaunchUpdateCheckPolicyTests: XCTestCase {
+    func testAllowsAutomaticCheckOnlyOnce() {
+        var policy = LaunchUpdateCheckPolicy()
+
+        XCTAssertTrue(policy.shouldStartAutomaticCheck())
+        XCTAssertFalse(policy.shouldStartAutomaticCheck())
+    }
+}


### PR DESCRIPTION
## Summary
- start the native GitHub release update check automatically when the macOS view launches
- keep the manual update button path intact while sharing the check implementation
- ignore generated SwiftPM Xcode workspace state

## Verification
- DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer swift test --package-path native
- DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer ./scripts/build-macos-app.sh (from native/)
- MCP_SERVER_REQUEST_TIMEOUT=300000 MCP_REQUEST_MAX_TOTAL_TIMEOUT=300000 MCP_XCODE_PID=18347 npx -y @modelcontextprotocol/inspector --cli /Applications/Xcode.app/Contents/Developer/usr/bin/mcpbridge --method tools/call --tool-name BuildProject --tool-arg tabIdentifier=windowtab1
- git diff --check