### PR TITLE
Bump native mac app to 0.1.2

### DIFF
--- a/native/AppBundle/Info.plist
+++ b/native/AppBundle/Info.plist
@@ -17,9 +17,9 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>0.1.1</string>
+	<string>0.1.2</string>
 	<key>CFBundleVersion</key>
-	<string>2</string>
+	<string>3</string>
 	<key>LSApplicationCategoryType</key>
 	<string>public.app-category.music</string>
 	<key>LSMinimumSystemVersion</key>

--- a/native/Tests/OscilloCoreTests/AppBundleMetadataTests.swift
+++ b/native/Tests/OscilloCoreTests/AppBundleMetadataTests.swift
@@ -15,8 +15,8 @@ final class AppBundleMetadataTests: XCTestCase {
         XCTAssertEqual(plist["CFBundleExecutable"] as? String, "OscilloMac")
         XCTAssertEqual(plist["CFBundlePackageType"] as? String, "APPL")
         XCTAssertEqual(plist["CFBundleIdentifier"] as? String, "com.zachyzissou.oscillo.native.mac")
-        XCTAssertEqual(plist["CFBundleShortVersionString"] as? String, "0.1.1")
-        XCTAssertEqual(plist["CFBundleVersion"] as? String, "2")
+        XCTAssertEqual(plist["CFBundleShortVersionString"] as? String, "0.1.2")
+        XCTAssertEqual(plist["CFBundleVersion"] as? String, "3")
         XCTAssertEqual(
             plist["NSMicrophoneUsageDescription"] as? String,
             "Oscillo uses microphone input to drive real-time audio-reactive visuals."


### PR DESCRIPTION
## Summary
- bump the native macOS app bundle version to 0.1.2 / build 3
- update the bundle metadata regression test to match the release build

## Verification
- DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer swift test --package-path native
- DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer ./scripts/build-macos-app.sh (from native/)
- MCP_SERVER_REQUEST_TIMEOUT=300000 MCP_REQUEST_MAX_TOTAL_TIMEOUT=300000 MCP_XCODE_PID=18347 npx -y @modelcontextprotocol/inspector --cli /Applications/Xcode.app/Contents/Developer/usr/bin/mcpbridge --method tools/call --tool-name BuildProject --tool-arg tabIdentifier=windowtab1
- git diff --check
- plutil -p native/dist/Oscillo.app/Contents/Info.plist | rg 'CFBundleShortVersionString|CFBundleVersion'