### PR TITLE
Wire Sparkle OTA releases

### DIFF
--- a/.github/workflows/native-release.yml
+++ b/.github/workflows/native-release.yml
@@ -85,12 +85,22 @@ jobs:
           fi
 
           echo "identity=$identity" >> "$GITHUB_OUTPUT"
+          echo "keychain_path=$keychain_path" >> "$GITHUB_OUTPUT"
 
       - name: Build app bundle
         working-directory: native
         env:
           CODE_SIGN_IDENTITY: ${{ steps.signing.outputs.identity }}
         run: ./Scripts/build-macos-app.sh
+
+      - name: Delete signing keychain
+        if: always()
+        env:
+          KEYCHAIN_PATH: ${{ steps.signing.outputs.keychain_path }}
+        run: |
+          if [ -n "${KEYCHAIN_PATH}" ] && [ -f "${KEYCHAIN_PATH}" ]; then
+            security delete-keychain "${KEYCHAIN_PATH}"
+          fi
 
       - name: Notarize and staple app
         working-directory: native
@@ -132,7 +142,11 @@ jobs:
           download_url="https://github.com/${REPOSITORY}/releases/download/${TAG_NAME}/${zip_name}"
           release_url="https://github.com/${REPOSITORY}/releases/tag/${TAG_NAME}"
           sparkle_archives_dir="dist/sparkle-appcast"
-          sparkle_tools_dir=".build/artifacts/sparkle/Sparkle/bin"
+          sparkle_tools_dir="$(find .build/artifacts -name generate_appcast -type f | head -1 | xargs dirname)"
+          if [ -z "$sparkle_tools_dir" ]; then
+            echo "generate_appcast not found under .build/artifacts; run 'swift build' first" >&2
+            exit 66
+          fi
 
           if [ -z "${SPARKLE_ED_PRIVATE_KEY}" ]; then
             echo "SPARKLE_ED_PRIVATE_KEY secret is required for native Sparkle releases" >&2

--- a/.github/workflows/native-release.yml
+++ b/.github/workflows/native-release.yml
@@ -69,7 +69,7 @@ jobs:
           keychain_path="${RUNNER_TEMP}/oscillo-signing.keychain-db"
           keychain_password="$(uuidgen)"
 
-          printf '%s' "$MACOS_DEVELOPER_ID_APPLICATION_P12_BASE64" | base64 --decode > "$cert_path"
+          printf '%s' "$MACOS_DEVELOPER_ID_APPLICATION_P12_BASE64" | base64 -D > "$cert_path"
           security create-keychain -p "$keychain_password" "$keychain_path"
           security set-keychain-settings -lut 21600 "$keychain_path"
           security unlock-keychain -p "$keychain_password" "$keychain_path"
@@ -155,7 +155,7 @@ jobs:
             echo "- Includes the latest signed app bundle for Sparkle OTA updates."
           } > "$sparkle_archives_dir/Oscillo-macOS-${VERSION}.md"
 
-          echo "$SPARKLE_ED_PRIVATE_KEY" | "$sparkle_tools_dir/generate_appcast" \
+          printf '%s' "$SPARKLE_ED_PRIVATE_KEY" | "$sparkle_tools_dir/generate_appcast" \
             --ed-key-file - \
             --download-url-prefix "https://github.com/${REPOSITORY}/releases/download/${TAG_NAME}/" \
             --link "$release_url" \

--- a/.github/workflows/native-release.yml
+++ b/.github/workflows/native-release.yml
@@ -142,11 +142,12 @@ jobs:
           download_url="https://github.com/${REPOSITORY}/releases/download/${TAG_NAME}/${zip_name}"
           release_url="https://github.com/${REPOSITORY}/releases/tag/${TAG_NAME}"
           sparkle_archives_dir="dist/sparkle-appcast"
-          sparkle_tools_dir="$(find .build/artifacts -name generate_appcast -type f | head -1 | xargs dirname)"
-          if [ -z "$sparkle_tools_dir" ]; then
-            echo "generate_appcast not found under .build/artifacts; run 'swift build' first" >&2
+          sparkle_generate_appcast="$(find .build/artifacts/sparkle -name generate_appcast -type f | head -1)"
+          if [ -z "$sparkle_generate_appcast" ]; then
+            echo "generate_appcast not found under .build/artifacts/sparkle; the Sparkle binary artifact may not have been extracted (expected after 'swift build --product OscilloMac')" >&2
             exit 66
           fi
+          sparkle_tools_dir="$(dirname "$sparkle_generate_appcast")"
 
           if [ -z "${SPARKLE_ED_PRIVATE_KEY}" ]; then
             echo "SPARKLE_ED_PRIVATE_KEY secret is required for native Sparkle releases" >&2

--- a/.github/workflows/native-release.yml
+++ b/.github/workflows/native-release.yml
@@ -54,9 +54,70 @@ jobs:
         working-directory: native
         run: swift test
 
+      - name: Import Developer ID certificate
+        id: signing
+        env:
+          MACOS_DEVELOPER_ID_APPLICATION_P12_BASE64: ${{ secrets.MACOS_DEVELOPER_ID_APPLICATION_P12_BASE64 }}
+          MACOS_DEVELOPER_ID_APPLICATION_P12_PASSWORD: ${{ secrets.MACOS_DEVELOPER_ID_APPLICATION_P12_PASSWORD }}
+        run: |
+          if [ -z "${MACOS_DEVELOPER_ID_APPLICATION_P12_BASE64}" ] || [ -z "${MACOS_DEVELOPER_ID_APPLICATION_P12_PASSWORD}" ]; then
+            echo "MACOS_DEVELOPER_ID_APPLICATION_P12_BASE64 and MACOS_DEVELOPER_ID_APPLICATION_P12_PASSWORD secrets are required for notarized native releases" >&2
+            exit 65
+          fi
+
+          cert_path="${RUNNER_TEMP}/developer-id-application.p12"
+          keychain_path="${RUNNER_TEMP}/oscillo-signing.keychain-db"
+          keychain_password="$(uuidgen)"
+
+          printf '%s' "$MACOS_DEVELOPER_ID_APPLICATION_P12_BASE64" | base64 --decode > "$cert_path"
+          security create-keychain -p "$keychain_password" "$keychain_path"
+          security set-keychain-settings -lut 21600 "$keychain_path"
+          security unlock-keychain -p "$keychain_password" "$keychain_path"
+          security import "$cert_path" -P "$MACOS_DEVELOPER_ID_APPLICATION_P12_PASSWORD" -A -t cert -f pkcs12 -k "$keychain_path"
+          security set-key-partition-list -S apple-tool:,apple:,codesign: -s -k "$keychain_password" "$keychain_path"
+          security list-keychains -d user -s "$keychain_path"
+
+          identity="$(security find-identity -v -p codesigning "$keychain_path" | awk -F '"' '/Developer ID Application/ { print $2; exit }')"
+          if [ -z "$identity" ]; then
+            echo "No Developer ID Application signing identity found in imported certificate" >&2
+            security find-identity -v -p codesigning "$keychain_path" >&2
+            exit 66
+          fi
+
+          echo "identity=$identity" >> "$GITHUB_OUTPUT"
+
       - name: Build app bundle
         working-directory: native
+        env:
+          CODE_SIGN_IDENTITY: ${{ steps.signing.outputs.identity }}
         run: ./Scripts/build-macos-app.sh
+
+      - name: Notarize and staple app
+        working-directory: native
+        env:
+          APPLE_ID: ${{ secrets.APPLE_ID }}
+          APPLE_APP_SPECIFIC_PASSWORD: ${{ secrets.APPLE_APP_SPECIFIC_PASSWORD }}
+          APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
+        run: |
+          if [ -z "${APPLE_ID}" ] || [ -z "${APPLE_APP_SPECIFIC_PASSWORD}" ] || [ -z "${APPLE_TEAM_ID}" ]; then
+            echo "APPLE_ID, APPLE_APP_SPECIFIC_PASSWORD, and APPLE_TEAM_ID secrets are required for notarized native releases" >&2
+            exit 65
+          fi
+
+          notary_zip="dist/Oscillo-notary.zip"
+          rm -f "$notary_zip"
+          ditto -c -k --sequesterRsrc --keepParent dist/Oscillo.app "$notary_zip"
+
+          xcrun notarytool submit "$notary_zip" \
+            --apple-id "$APPLE_ID" \
+            --password "$APPLE_APP_SPECIFIC_PASSWORD" \
+            --team-id "$APPLE_TEAM_ID" \
+            --wait
+
+          xcrun stapler staple dist/Oscillo.app
+          xcrun stapler validate dist/Oscillo.app
+          spctl -a -vvv --type execute dist/Oscillo.app
+          rm -f "$notary_zip"
 
       - name: Package release assets
         working-directory: native
@@ -64,16 +125,43 @@ jobs:
           TAG_NAME: ${{ steps.meta.outputs.tag }}
           VERSION: ${{ steps.meta.outputs.version }}
           REPOSITORY: ${{ github.repository }}
+          SPARKLE_ED_PRIVATE_KEY: ${{ secrets.SPARKLE_ED_PRIVATE_KEY }}
         run: |
           zip_name="Oscillo-macOS-${VERSION}.zip"
           zip_path="dist/${zip_name}"
           download_url="https://github.com/${REPOSITORY}/releases/download/${TAG_NAME}/${zip_name}"
           release_url="https://github.com/${REPOSITORY}/releases/tag/${TAG_NAME}"
+          sparkle_archives_dir="dist/sparkle-appcast"
+          sparkle_tools_dir=".build/artifacts/sparkle/Sparkle/bin"
 
-          rm -f "$zip_path" "$zip_path.sha256" dist/oscillo-native-update.json
-          ditto -c -k --keepParent dist/Oscillo.app "$zip_path"
+          if [ -z "${SPARKLE_ED_PRIVATE_KEY}" ]; then
+            echo "SPARKLE_ED_PRIVATE_KEY secret is required for native Sparkle releases" >&2
+            exit 65
+          fi
+
+          rm -f "$zip_path" "$zip_path.sha256" dist/oscillo-native-update.json dist/oscillo-appcast.xml
+          rm -rf "$sparkle_archives_dir"
+          mkdir -p "$sparkle_archives_dir"
+
+          ditto -c -k --sequesterRsrc --keepParent dist/Oscillo.app "$zip_path"
           sha256="$(shasum -a 256 "$zip_path" | awk '{print $1}')"
           printf '%s  %s\n' "$sha256" "$zip_name" > "$zip_path.sha256"
+
+          cp "$zip_path" "$sparkle_archives_dir/$zip_name"
+          {
+            echo "Oscillo Native ${VERSION}"
+            echo
+            echo "- Native macOS update ${TAG_NAME}"
+            echo "- Includes the latest signed app bundle for Sparkle OTA updates."
+          } > "$sparkle_archives_dir/Oscillo-macOS-${VERSION}.md"
+
+          echo "$SPARKLE_ED_PRIVATE_KEY" | "$sparkle_tools_dir/generate_appcast" \
+            --ed-key-file - \
+            --download-url-prefix "https://github.com/${REPOSITORY}/releases/download/${TAG_NAME}/" \
+            --link "$release_url" \
+            --embed-release-notes \
+            -o dist/oscillo-appcast.xml \
+            "$sparkle_archives_dir"
 
           python3 Scripts/generate-update-manifest.py \
             --version "$VERSION" \
@@ -97,6 +185,7 @@ jobs:
             echo "- Oscillo-macOS-${VERSION}.zip"
             echo "- Oscillo-macOS-${VERSION}.zip.sha256"
             echo "- oscillo-native-update.json"
+            echo "- oscillo-appcast.xml"
           } > "$notes_file"
 
           if gh release view "$TAG_NAME" >/dev/null 2>&1; then
@@ -104,12 +193,14 @@ jobs:
               "native/dist/Oscillo-macOS-${VERSION}.zip" \
               "native/dist/Oscillo-macOS-${VERSION}.zip.sha256" \
               "native/dist/oscillo-native-update.json" \
+              "native/dist/oscillo-appcast.xml" \
               --clobber
           else
             gh release create "$TAG_NAME" \
               "native/dist/Oscillo-macOS-${VERSION}.zip" \
               "native/dist/Oscillo-macOS-${VERSION}.zip.sha256" \
               "native/dist/oscillo-native-update.json" \
+              "native/dist/oscillo-appcast.xml" \
               --target "$GITHUB_SHA" \
               --title "Oscillo Native ${VERSION}" \
               --notes-file "$notes_file"

--- a/native/AppBundle/Info.plist
+++ b/native/AppBundle/Info.plist
@@ -30,5 +30,13 @@
 	<string>Oscillo uses microphone input to drive real-time audio-reactive visuals.</string>
 	<key>NSSupportsAutomaticGraphicsSwitching</key>
 	<true/>
+	<key>SUEnableAutomaticChecks</key>
+	<true/>
+	<key>SUEnableInstallerLauncherService</key>
+	<true/>
+	<key>SUFeedURL</key>
+	<string>https://github.com/zachyzissou/Oscillo/releases/latest/download/oscillo-appcast.xml</string>
+	<key>SUPublicEDKey</key>
+	<string>uNFkgAKuoZBfQZT4YWBKbEJCZX8IDdUnk8Gwdkiv0xw=</string>
 </dict>
 </plist>

--- a/native/AppBundle/OscilloMac.entitlements
+++ b/native/AppBundle/OscilloMac.entitlements
@@ -8,5 +8,10 @@
 	<true/>
 	<key>com.apple.security.network.client</key>
 	<true/>
+	<key>com.apple.security.temporary-exception.mach-lookup.global-name</key>
+	<array>
+		<string>com.zachyzissou.oscillo.native.mac-spks</string>
+		<string>com.zachyzissou.oscillo.native.mac-spki</string>
+	</array>
 </dict>
 </plist>

--- a/native/Package.resolved
+++ b/native/Package.resolved
@@ -1,0 +1,15 @@
+{
+  "originHash" : "f45c2e753929d15fc04fb9a38965b5f0e50ed06b7c27a312549138871c454be2",
+  "pins" : [
+    {
+      "identity" : "sparkle",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/sparkle-project/Sparkle",
+      "state" : {
+        "revision" : "066e75a8b3e99962685d6a90cdd5293ebffd9261",
+        "version" : "2.9.1"
+      }
+    }
+  ],
+  "version" : 3
+}

--- a/native/Package.swift
+++ b/native/Package.swift
@@ -11,11 +11,17 @@ let package = Package(
         .library(name: "OscilloCore", targets: ["OscilloCore"]),
         .executable(name: "OscilloMac", targets: ["OscilloMac"])
     ],
+    dependencies: [
+        .package(url: "https://github.com/sparkle-project/Sparkle", exact: "2.9.1")
+    ],
     targets: [
         .target(name: "OscilloCore"),
         .executableTarget(
             name: "OscilloMac",
-            dependencies: ["OscilloCore"]
+            dependencies: [
+                "OscilloCore",
+                .product(name: "Sparkle", package: "Sparkle")
+            ]
         ),
         .testTarget(
             name: "OscilloCoreTests",

--- a/native/Scripts/build-macos-app.sh
+++ b/native/Scripts/build-macos-app.sh
@@ -9,8 +9,18 @@ APP_DIR="$ROOT/dist/$APP_NAME.app"
 CONTENTS_DIR="$APP_DIR/Contents"
 MACOS_DIR="$CONTENTS_DIR/MacOS"
 RESOURCES_DIR="$CONTENTS_DIR/Resources"
+FRAMEWORKS_DIR="$CONTENTS_DIR/Frameworks"
 INFO_PLIST="$ROOT/AppBundle/Info.plist"
 ENTITLEMENTS="$ROOT/AppBundle/OscilloMac.entitlements"
+CODE_SIGN_IDENTITY="${CODE_SIGN_IDENTITY:--}"
+
+sign_item() {
+  if [[ "$CODE_SIGN_IDENTITY" = "-" ]]; then
+    codesign --force --sign "$CODE_SIGN_IDENTITY" "$@"
+  else
+    codesign --force --sign "$CODE_SIGN_IDENTITY" --timestamp --options runtime "$@"
+  fi
+}
 
 case "$CONFIGURATION" in
   debug|release)
@@ -22,24 +32,38 @@ case "$CONFIGURATION" in
 esac
 
 swift build --configuration "$CONFIGURATION" --product "$PRODUCT"
-BIN_PATH="$ROOT/.build/$CONFIGURATION"
+BIN_PATH="$(swift build --configuration "$CONFIGURATION" --show-bin-path)"
 EXECUTABLE="$BIN_PATH/$PRODUCT"
+SPARKLE_FRAMEWORK="$BIN_PATH/Sparkle.framework"
 
 if [[ ! -x "$EXECUTABLE" ]]; then
   echo "Expected executable not found: $EXECUTABLE" >&2
   exit 66
 fi
 
+if [[ ! -d "$SPARKLE_FRAMEWORK" ]]; then
+  echo "Expected Sparkle framework not found: $SPARKLE_FRAMEWORK" >&2
+  exit 66
+fi
+
 rm -rf "$APP_DIR"
-mkdir -p "$MACOS_DIR" "$RESOURCES_DIR"
+mkdir -p "$MACOS_DIR" "$RESOURCES_DIR" "$FRAMEWORKS_DIR"
 
 cp "$INFO_PLIST" "$CONTENTS_DIR/Info.plist"
 printf "APPL????" > "$CONTENTS_DIR/PkgInfo"
 cp "$EXECUTABLE" "$MACOS_DIR/$PRODUCT"
+ditto "$SPARKLE_FRAMEWORK" "$FRAMEWORKS_DIR/Sparkle.framework"
 chmod +x "$MACOS_DIR/$PRODUCT"
 
 plutil -lint "$CONTENTS_DIR/Info.plist" >/dev/null
-codesign --force --sign - --entitlements "$ENTITLEMENTS" "$APP_DIR" >/dev/null
+
+SPARKLE_APP_FRAMEWORK="$FRAMEWORKS_DIR/Sparkle.framework"
+sign_item "$SPARKLE_APP_FRAMEWORK/Versions/B/XPCServices/Installer.xpc" >/dev/null
+sign_item --preserve-metadata=entitlements "$SPARKLE_APP_FRAMEWORK/Versions/B/XPCServices/Downloader.xpc" >/dev/null
+sign_item "$SPARKLE_APP_FRAMEWORK/Versions/B/Autoupdate" >/dev/null
+sign_item "$SPARKLE_APP_FRAMEWORK/Versions/B/Updater.app" >/dev/null
+sign_item "$SPARKLE_APP_FRAMEWORK" >/dev/null
+sign_item --entitlements "$ENTITLEMENTS" "$APP_DIR" >/dev/null
 codesign --verify --deep --strict "$APP_DIR"
 
 echo "$APP_DIR"

--- a/native/Scripts/build-macos-app.sh
+++ b/native/Scripts/build-macos-app.sh
@@ -58,10 +58,11 @@ chmod +x "$MACOS_DIR/$PRODUCT"
 plutil -lint "$CONTENTS_DIR/Info.plist" >/dev/null
 
 SPARKLE_APP_FRAMEWORK="$FRAMEWORKS_DIR/Sparkle.framework"
-sign_item "$SPARKLE_APP_FRAMEWORK/Versions/B/XPCServices/Installer.xpc" >/dev/null
-sign_item --preserve-metadata=entitlements "$SPARKLE_APP_FRAMEWORK/Versions/B/XPCServices/Downloader.xpc" >/dev/null
-sign_item "$SPARKLE_APP_FRAMEWORK/Versions/B/Autoupdate" >/dev/null
-sign_item "$SPARKLE_APP_FRAMEWORK/Versions/B/Updater.app" >/dev/null
+SPARKLE_CURRENT_VERSION_DIR="$SPARKLE_APP_FRAMEWORK/Versions/Current"
+sign_item "$SPARKLE_CURRENT_VERSION_DIR/XPCServices/Installer.xpc" >/dev/null
+sign_item --preserve-metadata=entitlements "$SPARKLE_CURRENT_VERSION_DIR/XPCServices/Downloader.xpc" >/dev/null
+sign_item "$SPARKLE_CURRENT_VERSION_DIR/Autoupdate" >/dev/null
+sign_item "$SPARKLE_CURRENT_VERSION_DIR/Updater.app" >/dev/null
 sign_item "$SPARKLE_APP_FRAMEWORK" >/dev/null
 sign_item --entitlements "$ENTITLEMENTS" "$APP_DIR" >/dev/null
 codesign --verify --deep --strict "$APP_DIR"

--- a/native/Sources/OscilloMac/UpdateController.swift
+++ b/native/Sources/OscilloMac/UpdateController.swift
@@ -1,6 +1,7 @@
 import AppKit
 import Foundation
 import OscilloCore
+import Sparkle
 
 @MainActor
 final class UpdateController: ObservableObject {
@@ -9,17 +10,31 @@ final class UpdateController: ObservableObject {
     @Published private(set) var releaseURL: URL?
 
     private let service: GitHubUpdateService
+    private let sparkleUpdaterController: SPUStandardUpdaterController
     private var launchUpdateCheckPolicy = LaunchUpdateCheckPolicy()
 
-    init(service: GitHubUpdateService = GitHubUpdateService()) {
+    init(
+        service: GitHubUpdateService = GitHubUpdateService(),
+        sparkleUpdaterController: SPUStandardUpdaterController = SPUStandardUpdaterController(
+            startingUpdater: true,
+            updaterDelegate: nil,
+            userDriverDelegate: nil
+        )
+    ) {
         self.service = service
+        self.sparkleUpdaterController = sparkleUpdaterController
     }
 
     func checkNow() {
+        installUpdates()
         startCheck(
             statusText: "Checking GitHub Releases...",
             failurePrefix: "Update check failed"
         )
+    }
+
+    func installUpdates() {
+        sparkleUpdaterController.checkForUpdates(nil)
     }
 
     func checkAutomaticallyOnLaunch() {

--- a/native/Sources/OscilloMac/UpdateController.swift
+++ b/native/Sources/OscilloMac/UpdateController.swift
@@ -26,11 +26,9 @@ final class UpdateController: ObservableObject {
     }
 
     func checkNow() {
+        statusText = "Opening in-app update check..."
+        releaseURL = nil
         installUpdates()
-        startCheck(
-            statusText: "Checking GitHub Releases...",
-            failurePrefix: "Update check failed"
-        )
     }
 
     func installUpdates() {

--- a/native/Tests/OscilloCoreTests/AppBundleMetadataTests.swift
+++ b/native/Tests/OscilloCoreTests/AppBundleMetadataTests.swift
@@ -23,6 +23,21 @@ final class AppBundleMetadataTests: XCTestCase {
         )
     }
 
+    func testInfoPlistDeclaresSparkleUpdateFeed() throws {
+        let plist = try appInfoPlist()
+
+        XCTAssertEqual(
+            plist["SUFeedURL"] as? String,
+            "https://github.com/zachyzissou/Oscillo/releases/latest/download/oscillo-appcast.xml"
+        )
+        XCTAssertEqual(
+            plist["SUPublicEDKey"] as? String,
+            "uNFkgAKuoZBfQZT4YWBKbEJCZX8IDdUnk8Gwdkiv0xw="
+        )
+        XCTAssertEqual(plist["SUEnableAutomaticChecks"] as? Bool, true)
+        XCTAssertEqual(plist["SUEnableInstallerLauncherService"] as? Bool, true)
+    }
+
     func testEntitlementsAllowSandboxedAudioInput() throws {
         let plistURL = packageRoot()
             .appendingPathComponent("AppBundle")
@@ -36,6 +51,24 @@ final class AppBundleMetadataTests: XCTestCase {
         XCTAssertEqual(plist["com.apple.security.app-sandbox"] as? Bool, true)
         XCTAssertEqual(plist["com.apple.security.device.audio-input"] as? Bool, true)
         XCTAssertEqual(plist["com.apple.security.network.client"] as? Bool, true)
+        XCTAssertEqual(
+            plist["com.apple.security.temporary-exception.mach-lookup.global-name"] as? [String],
+            [
+                "com.zachyzissou.oscillo.native.mac-spks",
+                "com.zachyzissou.oscillo.native.mac-spki"
+            ]
+        )
+    }
+
+    private func appInfoPlist() throws -> [String: Any] {
+        let plistURL = packageRoot()
+            .appendingPathComponent("AppBundle")
+            .appendingPathComponent("Info.plist")
+        let data = try Data(contentsOf: plistURL)
+        return try XCTUnwrap(
+            PropertyListSerialization.propertyList(from: data, options: [], format: nil)
+                as? [String: Any]
+        )
     }
 
     private func packageRoot() -> URL {

--- a/native/UPDATES.md
+++ b/native/UPDATES.md
@@ -1,6 +1,6 @@
 # Native Update Channel
 
-Oscillo now has the first GitHub-backed native update lane.
+Oscillo has a GitHub-backed native update lane plus a Sparkle OTA install path.
 
 ## Current Behavior
 
@@ -8,9 +8,10 @@ Oscillo now has the first GitHub-backed native update lane.
 - The app includes a visible `Check Updates` control.
 - The update check calls GitHub Releases for `zachyzissou/Oscillo`.
 - If a newer `native-vX.Y.Z` release exists, the app enables an `Open Release` button.
-- Release builds publish a macOS zip asset and `oscillo-native-update.json` manifest.
+- Release builds publish a notarized macOS zip asset, `oscillo-native-update.json`, and a Sparkle `oscillo-appcast.xml`.
+- Sparkle uses the appcast to download and install signed updates in-app.
 
-This is enough for test builds on a MacBook Pro without pretending we have secure self-replacement yet.
+The GitHub release check remains in the UI as a visible status and fallback path. Sparkle handles the actual OTA install flow.
 
 ## Release Flow
 
@@ -32,17 +33,19 @@ Both paths build and publish:
 - `Oscillo-macOS-<version>.zip`
 - `Oscillo-macOS-<version>.zip.sha256`
 - `oscillo-native-update.json`
+- `oscillo-appcast.xml`
 
-## Secure OTA Install Path
+## Signing and Notarization
 
-For automatic in-app download/install, use Sparkle 2 once the project has a full Xcode app target and signing secrets.
+GitHub native releases require Apple Developer ID signing and notarization secrets before publishing update assets:
 
-Required future work:
+- `MACOS_DEVELOPER_ID_APPLICATION_P12_BASE64`: base64-encoded `.p12` export for a `Developer ID Application` certificate.
+- `MACOS_DEVELOPER_ID_APPLICATION_P12_PASSWORD`: password for the `.p12` export.
+- `APPLE_ID`: Apple ID used for notarization.
+- `APPLE_APP_SPECIFIC_PASSWORD`: app-specific password for `notarytool`.
+- `APPLE_TEAM_ID`: Apple Developer Program team ID.
+- `SPARKLE_ED_PRIVATE_KEY`: Sparkle EdDSA private key for signing appcast update items.
 
-- Add Sparkle as a Swift package or embedded framework in the Xcode app target.
-- Generate and protect Sparkle EdDSA private key outside the repo.
-- Add the Sparkle public key and appcast URL to app metadata.
-- Use Developer ID signing and notarization for public MacBook installs.
-- Publish Sparkle appcast assets from the native release workflow.
+The matching Sparkle public key lives in `AppBundle/Info.plist` as `SUPublicEDKey`.
 
-Sparkle is the right self-update mechanism for direct-distributed macOS apps. The current GitHub release check is the safe interim step.
+Developer ID signing plus notarization is what prevents the recurring Gatekeeper "Open Anyway" approval flow for direct-download builds. Sparkle's EdDSA signature protects the update feed and archive, but it does not replace Apple's Gatekeeper trust chain.


### PR DESCRIPTION
## Summary
- add Sparkle 2.9.1 to the native Swift package and wire the macOS app's manual update action through `SPUStandardUpdaterController`
- add the Sparkle feed URL, public EdDSA key, sandbox installer service metadata, and mach lookup entitlements
- update native release publishing to Developer ID sign, notarize, staple, package, and generate a signed Sparkle appcast asset
- document the required GitHub secrets for Developer ID signing, Apple notarization, and Sparkle appcast signing

Refs #416
Refs #417

## Validation
- `DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer swift test --package-path native`
- `DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer ./Scripts/build-macos-app.sh`
- local Sparkle `generate_appcast` run with the private key file; verified XML, `sparkle:edSignature`, and GitHub release asset URL
- `DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer xcodebuild -scheme OscilloMac -destination 'platform=macOS' build`
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/native-release.yml"); puts "native-release.yml parsed"'`
- `bash -n native/Scripts/build-macos-app.sh`
- `git diff --check`

## Release note
Native releases now require these repository secrets before a `native-vX.Y.Z` release can publish notarized OTA assets: `MACOS_DEVELOPER_ID_APPLICATION_P12_BASE64`, `MACOS_DEVELOPER_ID_APPLICATION_P12_PASSWORD`, `APPLE_ID`, `APPLE_APP_SPECIFIC_PASSWORD`, `APPLE_TEAM_ID`, and `SPARKLE_ED_PRIVATE_KEY`.
