### PR TITLE
Add macOS signing secret setup helper

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,7 @@ package-lock.json
 native/.build/
 native/.swiftpm/
 native/dist/
+native/secrets/
 tsconfig.tsbuildinfo
 
 # Test artifacts and build results

--- a/native/Scripts/configure-macos-signing-secrets.sh
+++ b/native/Scripts/configure-macos-signing-secrets.sh
@@ -2,6 +2,7 @@
 set -euo pipefail
 
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+REPOSITORY="${REPOSITORY:-}"
 SECRETS_DIR="$ROOT/secrets"
 KEY_PATH="${KEY_PATH:-$SECRETS_DIR/OscilloDeveloperIDApplication.key}"
 P12_PATH="${P12_PATH:-$SECRETS_DIR/OscilloDeveloperIDApplication.p12}"
@@ -16,30 +17,13 @@ Usage:
   native/Scripts/configure-macos-signing-secrets.sh /path/to/developer_id_application.cer
 
 The matching private key must exist at native/secrets/OscilloDeveloperIDApplication.key.
+Set REPOSITORY=owner/name to override the GitHub repository detected from the current checkout.
 EOF
 }
 
 if [[ $# -ne 1 ]]; then
   usage
   exit 64
-fi
-
-# Preflight: require gh CLI installed and authenticated before touching key material
-if ! command -v gh >/dev/null 2>&1; then
-  echo "GitHub CLI (gh) is not installed. Install from https://cli.github.com then run: gh auth login" >&2
-  exit 69  # EX_UNAVAILABLE
-fi
-if ! gh auth status >/dev/null 2>&1; then
-  echo "GitHub CLI is not authenticated. Run: gh auth login" >&2
-  exit 77  # EX_NOPERM
-fi
-
-# Derive repository from the current git remote if not explicitly overridden
-if [[ -z "${REPOSITORY:-}" ]]; then
-  REPOSITORY="$(gh repo view --json nameWithOwner -q .nameWithOwner 2>/dev/null)" || {
-    echo "Could not determine repository. Set REPOSITORY=owner/repo or run from inside a cloned repository." >&2
-    exit 78  # EX_CONFIG
-  }
 fi
 
 CER_PATH="$1"
@@ -57,6 +41,25 @@ if [[ -z "${APPLE_ID:-}" || -z "${APPLE_TEAM_ID:-}" || -z "${APPLE_APP_SPECIFIC_
   echo "APPLE_ID, APPLE_TEAM_ID, and APPLE_APP_SPECIFIC_PASSWORD must be set." >&2
   usage
   exit 64
+fi
+
+if ! command -v gh >/dev/null 2>&1; then
+  echo "GitHub CLI is required to store repository secrets." >&2
+  exit 69
+fi
+
+if ! gh auth status >/dev/null 2>&1; then
+  echo "GitHub CLI is not authenticated. Run 'gh auth login' before storing secrets." >&2
+  exit 69
+fi
+
+if [[ -z "$REPOSITORY" ]]; then
+  REPOSITORY="$(gh repo view --json nameWithOwner --jq .nameWithOwner 2>/dev/null || true)"
+fi
+
+if [[ -z "$REPOSITORY" ]]; then
+  echo "Unable to determine GitHub repository. Set REPOSITORY=owner/name and retry." >&2
+  exit 69
 fi
 
 mkdir -p "$SECRETS_DIR"

--- a/native/Scripts/configure-macos-signing-secrets.sh
+++ b/native/Scripts/configure-macos-signing-secrets.sh
@@ -2,7 +2,6 @@
 set -euo pipefail
 
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
-REPOSITORY="${REPOSITORY:-}"
 SECRETS_DIR="$ROOT/secrets"
 KEY_PATH="${KEY_PATH:-$SECRETS_DIR/OscilloDeveloperIDApplication.key}"
 P12_PATH="${P12_PATH:-$SECRETS_DIR/OscilloDeveloperIDApplication.p12}"
@@ -17,13 +16,30 @@ Usage:
   native/Scripts/configure-macos-signing-secrets.sh /path/to/developer_id_application.cer
 
 The matching private key must exist at native/secrets/OscilloDeveloperIDApplication.key.
-Set REPOSITORY=owner/name to override the GitHub repository detected from the current checkout.
 EOF
 }
 
 if [[ $# -ne 1 ]]; then
   usage
   exit 64
+fi
+
+# Preflight: require gh CLI installed and authenticated before touching key material
+if ! command -v gh >/dev/null 2>&1; then
+  echo "GitHub CLI (gh) is not installed. Install from https://cli.github.com then run: gh auth login" >&2
+  exit 69  # EX_UNAVAILABLE
+fi
+if ! gh auth status >/dev/null 2>&1; then
+  echo "GitHub CLI is not authenticated. Run: gh auth login" >&2
+  exit 77  # EX_NOPERM
+fi
+
+# Derive repository from the current git remote if not explicitly overridden
+if [[ -z "${REPOSITORY:-}" ]]; then
+  REPOSITORY="$(gh repo view --json nameWithOwner -q .nameWithOwner 2>/dev/null)" || {
+    echo "Could not determine repository. Set REPOSITORY=owner/repo or run from inside a cloned repository." >&2
+    exit 78  # EX_CONFIG
+  }
 fi
 
 CER_PATH="$1"
@@ -41,25 +57,6 @@ if [[ -z "${APPLE_ID:-}" || -z "${APPLE_TEAM_ID:-}" || -z "${APPLE_APP_SPECIFIC_
   echo "APPLE_ID, APPLE_TEAM_ID, and APPLE_APP_SPECIFIC_PASSWORD must be set." >&2
   usage
   exit 64
-fi
-
-if ! command -v gh >/dev/null 2>&1; then
-  echo "GitHub CLI is required to store repository secrets." >&2
-  exit 69
-fi
-
-if ! gh auth status >/dev/null 2>&1; then
-  echo "GitHub CLI is not authenticated. Run 'gh auth login' before storing secrets." >&2
-  exit 69
-fi
-
-if [[ -z "$REPOSITORY" ]]; then
-  REPOSITORY="$(gh repo view --json nameWithOwner --jq .nameWithOwner 2>/dev/null || true)"
-fi
-
-if [[ -z "$REPOSITORY" ]]; then
-  echo "Unable to determine GitHub repository. Set REPOSITORY=owner/name and retry." >&2
-  exit 69
 fi
 
 mkdir -p "$SECRETS_DIR"

--- a/native/Scripts/configure-macos-signing-secrets.sh
+++ b/native/Scripts/configure-macos-signing-secrets.sh
@@ -1,0 +1,84 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+REPOSITORY="${REPOSITORY:-zachyzissou/Oscillo}"
+SECRETS_DIR="$ROOT/secrets"
+KEY_PATH="${KEY_PATH:-$SECRETS_DIR/OscilloDeveloperIDApplication.key}"
+P12_PATH="${P12_PATH:-$SECRETS_DIR/OscilloDeveloperIDApplication.p12}"
+P12_PASSWORD_PATH="${P12_PASSWORD_PATH:-$SECRETS_DIR/OscilloDeveloperIDApplication.p12.password}"
+
+usage() {
+  cat >&2 <<'EOF'
+Usage:
+  APPLE_ID=you@example.com \
+  APPLE_TEAM_ID=TEAMID \
+  APPLE_APP_SPECIFIC_PASSWORD=xxxx-xxxx-xxxx-xxxx \
+  ./Scripts/configure-macos-signing-secrets.sh /path/to/developer_id_application.cer
+
+The matching private key must exist at native/secrets/OscilloDeveloperIDApplication.key.
+EOF
+}
+
+if [[ $# -ne 1 ]]; then
+  usage
+  exit 64
+fi
+
+CER_PATH="$1"
+if [[ ! -f "$CER_PATH" ]]; then
+  echo "Certificate file not found: $CER_PATH" >&2
+  exit 66
+fi
+
+if [[ ! -f "$KEY_PATH" ]]; then
+  echo "Developer ID private key not found: $KEY_PATH" >&2
+  exit 66
+fi
+
+if [[ -z "${APPLE_ID:-}" || -z "${APPLE_TEAM_ID:-}" || -z "${APPLE_APP_SPECIFIC_PASSWORD:-}" ]]; then
+  echo "APPLE_ID, APPLE_TEAM_ID, and APPLE_APP_SPECIFIC_PASSWORD must be set." >&2
+  usage
+  exit 64
+fi
+
+mkdir -p "$SECRETS_DIR"
+chmod 700 "$SECRETS_DIR"
+
+cert_pem="$SECRETS_DIR/OscilloDeveloperIDApplication.pem"
+if openssl x509 -inform DER -in "$CER_PATH" -noout >/dev/null 2>&1; then
+  openssl x509 -inform DER -in "$CER_PATH" -out "$cert_pem"
+else
+  openssl x509 -in "$CER_PATH" -out "$cert_pem"
+fi
+
+cert_modulus="$(openssl x509 -noout -modulus -in "$cert_pem" | openssl dgst -sha256)"
+key_modulus="$(openssl rsa -noout -modulus -in "$KEY_PATH" 2>/dev/null | openssl dgst -sha256)"
+if [[ "$cert_modulus" != "$key_modulus" ]]; then
+  echo "The certificate does not match $KEY_PATH. Recreate the certificate with the CSR in native/secrets." >&2
+  exit 65
+fi
+
+p12_password="${MACOS_DEVELOPER_ID_APPLICATION_P12_PASSWORD:-$(openssl rand -base64 36)}"
+printf '%s' "$p12_password" > "$P12_PASSWORD_PATH"
+chmod 600 "$P12_PASSWORD_PATH"
+
+openssl pkcs12 -export \
+  -inkey "$KEY_PATH" \
+  -in "$cert_pem" \
+  -out "$P12_PATH" \
+  -passout "pass:$p12_password" >/dev/null
+chmod 600 "$P12_PATH"
+
+base64_path="$SECRETS_DIR/OscilloDeveloperIDApplication.p12.base64"
+base64 -i "$P12_PATH" | tr -d '\n' > "$base64_path"
+chmod 600 "$base64_path"
+
+gh secret set MACOS_DEVELOPER_ID_APPLICATION_P12_BASE64 --repo "$REPOSITORY" < "$base64_path"
+printf '%s' "$p12_password" | gh secret set MACOS_DEVELOPER_ID_APPLICATION_P12_PASSWORD --repo "$REPOSITORY"
+printf '%s' "$APPLE_ID" | gh secret set APPLE_ID --repo "$REPOSITORY"
+printf '%s' "$APPLE_TEAM_ID" | gh secret set APPLE_TEAM_ID --repo "$REPOSITORY"
+printf '%s' "$APPLE_APP_SPECIFIC_PASSWORD" | gh secret set APPLE_APP_SPECIFIC_PASSWORD --repo "$REPOSITORY"
+
+echo "Stored macOS signing and notarization secrets for $REPOSITORY."
+echo "Local p12: $P12_PATH"

--- a/native/Scripts/configure-macos-signing-secrets.sh
+++ b/native/Scripts/configure-macos-signing-secrets.sh
@@ -2,7 +2,6 @@
 set -euo pipefail
 
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
-REPOSITORY="${REPOSITORY:-zachyzissou/Oscillo}"
 SECRETS_DIR="$ROOT/secrets"
 KEY_PATH="${KEY_PATH:-$SECRETS_DIR/OscilloDeveloperIDApplication.key}"
 P12_PATH="${P12_PATH:-$SECRETS_DIR/OscilloDeveloperIDApplication.p12}"
@@ -14,7 +13,7 @@ Usage:
   APPLE_ID=you@example.com \
   APPLE_TEAM_ID=TEAMID \
   APPLE_APP_SPECIFIC_PASSWORD=xxxx-xxxx-xxxx-xxxx \
-  ./Scripts/configure-macos-signing-secrets.sh /path/to/developer_id_application.cer
+  native/Scripts/configure-macos-signing-secrets.sh /path/to/developer_id_application.cer
 
 The matching private key must exist at native/secrets/OscilloDeveloperIDApplication.key.
 EOF
@@ -23,6 +22,24 @@ EOF
 if [[ $# -ne 1 ]]; then
   usage
   exit 64
+fi
+
+# Preflight: require gh CLI installed and authenticated before touching key material
+if ! command -v gh >/dev/null 2>&1; then
+  echo "GitHub CLI (gh) is not installed. Install from https://cli.github.com then run: gh auth login" >&2
+  exit 69  # EX_UNAVAILABLE
+fi
+if ! gh auth status >/dev/null 2>&1; then
+  echo "GitHub CLI is not authenticated. Run: gh auth login" >&2
+  exit 77  # EX_NOPERM
+fi
+
+# Derive repository from the current git remote if not explicitly overridden
+if [[ -z "${REPOSITORY:-}" ]]; then
+  REPOSITORY="$(gh repo view --json nameWithOwner -q .nameWithOwner 2>/dev/null)" || {
+    echo "Could not determine repository. Set REPOSITORY=owner/repo or run from inside a cloned repository." >&2
+    exit 78  # EX_CONFIG
+  }
 fi
 
 CER_PATH="$1"
@@ -71,7 +88,7 @@ openssl pkcs12 -export \
 chmod 600 "$P12_PATH"
 
 base64_path="$SECRETS_DIR/OscilloDeveloperIDApplication.p12.base64"
-base64 -i "$P12_PATH" | tr -d '\n' > "$base64_path"
+base64 < "$P12_PATH" | tr -d '\n' > "$base64_path"
 chmod 600 "$base64_path"
 
 gh secret set MACOS_DEVELOPER_ID_APPLICATION_P12_BASE64 --repo "$REPOSITORY" < "$base64_path"

--- a/native/UPDATES.md
+++ b/native/UPDATES.md
@@ -49,3 +49,22 @@ GitHub native releases require Apple Developer ID signing and notarization secre
 The matching Sparkle public key lives in `AppBundle/Info.plist` as `SUPublicEDKey`.
 
 Developer ID signing plus notarization is what prevents the recurring Gatekeeper "Open Anyway" approval flow for direct-download builds. Sparkle's EdDSA signature protects the update feed and archive, but it does not replace Apple's Gatekeeper trust chain.
+
+## First-Time Secret Setup
+
+Generate a Developer ID Application certificate from the Apple Developer portal using the CSR at:
+
+```bash
+native/secrets/OscilloDeveloperIDApplication.certSigningRequest
+```
+
+After downloading the `.cer`, store the release secrets:
+
+```bash
+APPLE_ID="you@example.com" \
+APPLE_TEAM_ID="TEAMID" \
+APPLE_APP_SPECIFIC_PASSWORD="xxxx-xxxx-xxxx-xxxx" \
+./Scripts/configure-macos-signing-secrets.sh /path/to/developer_id_application.cer
+```
+
+The script builds a password-protected `.p12` from the local private key, pushes the GitHub secrets, and leaves the generated key material under ignored `native/secrets/`.

--- a/native/UPDATES.md
+++ b/native/UPDATES.md
@@ -64,7 +64,7 @@ After downloading the `.cer`, store the release secrets:
 APPLE_ID="you@example.com" \
 APPLE_TEAM_ID="TEAMID" \
 APPLE_APP_SPECIFIC_PASSWORD="xxxx-xxxx-xxxx-xxxx" \
-./Scripts/configure-macos-signing-secrets.sh /path/to/developer_id_application.cer
+native/Scripts/configure-macos-signing-secrets.sh /path/to/developer_id_application.cer
 ```
 
 The script builds a password-protected `.p12` from the local private key, pushes the GitHub secrets, and leaves the generated key material under ignored `native/secrets/`.


### PR DESCRIPTION
## Summary
- ignore local `native/secrets/` signing material
- add a helper script that converts the Apple Developer ID `.cer` plus local CSR private key into a `.p12`
- push the required Developer ID and notarization values into GitHub Actions secrets without printing them
- document the first-time signing secret setup flow in `native/UPDATES.md`

Refs #417

## Validation
- `bash -n native/Scripts/configure-macos-signing-secrets.sh`
- `bash -lc 'set +e; native/Scripts/configure-macos-signing-secrets.sh >/tmp/oscillo-signing-usage.txt 2>&1; rc=$?; sed -n "1,80p" /tmp/oscillo-signing-usage.txt; test "$rc" -eq 64'`
- `git check-ignore -v native/secrets/OscilloDeveloperIDApplication.key native/secrets/OscilloDeveloperIDApplication.certSigningRequest`
