### PR TITLE
Fix Sparkle framework rpath for native releases

### DIFF
--- a/.github/workflows/native-macos.yml
+++ b/.github/workflows/native-macos.yml
@@ -44,6 +44,14 @@ jobs:
         working-directory: native
         run: codesign --verify --deep --strict dist/Oscillo.app
 
+      - name: Verify bundled framework rpath
+        working-directory: native
+        run: |
+          if ! otool -l dist/Oscillo.app/Contents/MacOS/OscilloMac | grep -q '@executable_path/../Frameworks'; then
+            echo "OscilloMac is missing @executable_path/../Frameworks rpath for bundled frameworks" >&2
+            exit 66
+          fi
+
       - name: Zip app artifact
         working-directory: native
         run: |

--- a/.github/workflows/native-release.yml
+++ b/.github/workflows/native-release.yml
@@ -93,6 +93,14 @@ jobs:
           CODE_SIGN_IDENTITY: ${{ steps.signing.outputs.identity }}
         run: ./Scripts/build-macos-app.sh
 
+      - name: Verify bundled framework rpath
+        working-directory: native
+        run: |
+          if ! otool -l dist/Oscillo.app/Contents/MacOS/OscilloMac | grep -q '@executable_path/../Frameworks'; then
+            echo "OscilloMac is missing @executable_path/../Frameworks rpath for bundled frameworks" >&2
+            exit 66
+          fi
+
       - name: Delete signing keychain
         if: always()
         env:

--- a/native/AppBundle/Info.plist
+++ b/native/AppBundle/Info.plist
@@ -17,9 +17,9 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>0.1.3</string>
+	<string>0.1.4</string>
 	<key>CFBundleVersion</key>
-	<string>4</string>
+	<string>5</string>
 	<key>LSApplicationCategoryType</key>
 	<string>public.app-category.music</string>
 	<key>LSMinimumSystemVersion</key>

--- a/native/Scripts/build-macos-app.sh
+++ b/native/Scripts/build-macos-app.sh
@@ -57,6 +57,10 @@ chmod +x "$MACOS_DIR/$PRODUCT"
 
 plutil -lint "$CONTENTS_DIR/Info.plist" >/dev/null
 
+if ! otool -l "$MACOS_DIR/$PRODUCT" | grep -q "@executable_path/../Frameworks"; then
+  install_name_tool -add_rpath "@executable_path/../Frameworks" "$MACOS_DIR/$PRODUCT"
+fi
+
 SPARKLE_APP_FRAMEWORK="$FRAMEWORKS_DIR/Sparkle.framework"
 SPARKLE_CURRENT_VERSION_DIR="$SPARKLE_APP_FRAMEWORK/Versions/Current"
 sign_item "$SPARKLE_CURRENT_VERSION_DIR/XPCServices/Installer.xpc" >/dev/null

--- a/native/Tests/OscilloCoreTests/AppBundleMetadataTests.swift
+++ b/native/Tests/OscilloCoreTests/AppBundleMetadataTests.swift
@@ -15,8 +15,8 @@ final class AppBundleMetadataTests: XCTestCase {
         XCTAssertEqual(plist["CFBundleExecutable"] as? String, "OscilloMac")
         XCTAssertEqual(plist["CFBundlePackageType"] as? String, "APPL")
         XCTAssertEqual(plist["CFBundleIdentifier"] as? String, "com.zachyzissou.oscillo.native.mac")
-        XCTAssertEqual(plist["CFBundleShortVersionString"] as? String, "0.1.3")
-        XCTAssertEqual(plist["CFBundleVersion"] as? String, "4")
+        XCTAssertEqual(plist["CFBundleShortVersionString"] as? String, "0.1.4")
+        XCTAssertEqual(plist["CFBundleVersion"] as? String, "5")
         XCTAssertEqual(
             plist["NSMicrophoneUsageDescription"] as? String,
             "Oscillo uses microphone input to drive real-time audio-reactive visuals."


### PR DESCRIPTION
## Summary
- add `@executable_path/../Frameworks` rpath to the packaged native executable before signing
- add CI/release workflow checks so missing bundled framework rpaths fail before publishing
- bump native macOS app to 0.1.4 / build 5

## Root cause
The signed/notarized 0.1.3 asset could not launch because `OscilloMac` linked `@rpath/Sparkle.framework/...` but the packaged executable only had Swift toolchain rpaths. The app bundle contained Sparkle under `Contents/Frameworks`, but dyld had no rpath to search there. I marked `native-v0.1.3` as a prerelease to keep it out of latest while this fix ships.

## Validation
- `DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer swift test`
- `DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer CONFIGURATION=release ./Scripts/build-macos-app.sh`
- packaged executable runtime smoke: launched `dist/Oscillo.app/Contents/MacOS/OscilloMac` for 3s and confirmed it stayed alive (`RUNTIME_SMOKE_OK`)
- `git ls-files native/secrets` returns no tracked files
