### PR TITLE
Add native build marker for OTA smoke

### DIFF
--- a/native/AppBundle/Info.plist
+++ b/native/AppBundle/Info.plist
@@ -17,9 +17,9 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>0.1.4</string>
+	<string>0.1.5</string>
 	<key>CFBundleVersion</key>
-	<string>5</string>
+	<string>6</string>
 	<key>LSApplicationCategoryType</key>
 	<string>public.app-category.music</string>
 	<key>LSMinimumSystemVersion</key>

--- a/native/Sources/OscilloCore/AppBuildMetadata.swift
+++ b/native/Sources/OscilloCore/AppBuildMetadata.swift
@@ -1,0 +1,22 @@
+import Foundation
+
+public struct AppBuildMetadata: Equatable, Sendable {
+    public let shortVersion: String
+    public let buildNumber: String
+
+    public init(shortVersion: String, buildNumber: String) {
+        self.shortVersion = shortVersion
+        self.buildNumber = buildNumber
+    }
+
+    public init(bundleInfo: [String: Any]) {
+        self.init(
+            shortVersion: bundleInfo["CFBundleShortVersionString"] as? String ?? "unknown",
+            buildNumber: bundleInfo["CFBundleVersion"] as? String ?? "unknown"
+        )
+    }
+
+    public var visibleBuildMarker: String {
+        "v\(shortVersion) build \(buildNumber)"
+    }
+}

--- a/native/Sources/OscilloMac/ContentView.swift
+++ b/native/Sources/OscilloMac/ContentView.swift
@@ -33,12 +33,20 @@ private struct ControlPanel: View {
     @ObservedObject var audioEngine: LiveAudioEngine
     @ObservedObject var sceneController: SceneController
     @ObservedObject var updateController: UpdateController
+    private let buildMetadata = AppBuildMetadata(bundleInfo: Bundle.main.infoDictionary ?? [:])
 
     var body: some View {
         VStack(alignment: .leading, spacing: 16) {
             VStack(alignment: .leading, spacing: 4) {
-                Text("Oscillo")
-                    .font(.system(size: 20, weight: .semibold, design: .rounded))
+                HStack(alignment: .firstTextBaseline) {
+                    Text("Oscillo")
+                        .font(.system(size: 20, weight: .semibold, design: .rounded))
+                    Spacer(minLength: 10)
+                    Text(buildMetadata.visibleBuildMarker)
+                        .font(.caption2.monospacedDigit())
+                        .foregroundStyle(.secondary)
+                }
+
                 Text(audioEngine.statusMessage)
                     .font(.caption)
                     .foregroundStyle(.secondary)

--- a/native/Tests/OscilloCoreTests/AppBuildMetadataTests.swift
+++ b/native/Tests/OscilloCoreTests/AppBuildMetadataTests.swift
@@ -1,0 +1,15 @@
+import XCTest
+@testable import OscilloCore
+
+final class AppBuildMetadataTests: XCTestCase {
+    func testFormatsVisibleVersionAndBuildMarker() {
+        let metadata = AppBuildMetadata(
+            bundleInfo: [
+                "CFBundleShortVersionString": "0.1.5",
+                "CFBundleVersion": "6"
+            ]
+        )
+
+        XCTAssertEqual(metadata.visibleBuildMarker, "v0.1.5 build 6")
+    }
+}

--- a/native/Tests/OscilloCoreTests/AppBuildMetadataTests.swift
+++ b/native/Tests/OscilloCoreTests/AppBuildMetadataTests.swift
@@ -5,11 +5,11 @@ final class AppBuildMetadataTests: XCTestCase {
     func testFormatsVisibleVersionAndBuildMarker() {
         let metadata = AppBuildMetadata(
             bundleInfo: [
-                "CFBundleShortVersionString": "0.1.5",
-                "CFBundleVersion": "6"
+                "CFBundleShortVersionString": "1.2.3",
+                "CFBundleVersion": "456"
             ]
         )
 
-        XCTAssertEqual(metadata.visibleBuildMarker, "v0.1.5 build 6")
+        XCTAssertEqual(metadata.visibleBuildMarker, "v1.2.3 build 456")
     }
 }

--- a/native/Tests/OscilloCoreTests/AppBundleMetadataTests.swift
+++ b/native/Tests/OscilloCoreTests/AppBundleMetadataTests.swift
@@ -15,8 +15,8 @@ final class AppBundleMetadataTests: XCTestCase {
         XCTAssertEqual(plist["CFBundleExecutable"] as? String, "OscilloMac")
         XCTAssertEqual(plist["CFBundlePackageType"] as? String, "APPL")
         XCTAssertEqual(plist["CFBundleIdentifier"] as? String, "com.zachyzissou.oscillo.native.mac")
-        XCTAssertEqual(plist["CFBundleShortVersionString"] as? String, "0.1.4")
-        XCTAssertEqual(plist["CFBundleVersion"] as? String, "5")
+        XCTAssertEqual(plist["CFBundleShortVersionString"] as? String, "0.1.5")
+        XCTAssertEqual(plist["CFBundleVersion"] as? String, "6")
         XCTAssertEqual(
             plist["NSMicrophoneUsageDescription"] as? String,
             "Oscillo uses microphone input to drive real-time audio-reactive visuals."


### PR DESCRIPTION
## Summary
- add a visible `vX.Y.Z build N` marker to the native macOS control panel
- add `AppBuildMetadata` coverage for bundle version/build formatting
- bump native macOS app to 0.1.5 / build 6 for the OTA smoke release

## Why
`native-v0.1.4` is the first correctly packaged Sparkle-capable release. This gives the next release a visible marker so we can prove the in-app Sparkle update moved the app from 0.1.4 to 0.1.5.

## Validation
- `DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer swift test --filter AppBuildMetadataTests`
- `DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer swift test`
- `DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer CONFIGURATION=release ./Scripts/build-macos-app.sh`
- packaged app metadata/rpath/runtime smoke: `0.1.5`, build `6`, `RPATH_OK`, `RUNTIME_SMOKE_OK`
- `git ls-files native/secrets` returns no tracked files

Closes #428 after the 0.1.5 release is published and the Sparkle OTA path is verified from 0.1.4.
