### PR TITLE
docs(native): add Stitch workflow

### DIFF
--- a/docs/STITCH_WORKFLOW.md
+++ b/docs/STITCH_WORKFLOW.md
@@ -1,0 +1,122 @@
+# Oscillo Stitch Workflow
+
+Use Google Stitch as a visual exploration surface for the native Swift/macOS lane. The source of truth for product direction is `native/DESIGN_DIRECTION.md`; Stitch output is reference material, not production code.
+
+Important distinction:
+
+- `native/DESIGN_DIRECTION.md` describes the native product direction.
+- `native/APPLE_TECH_MAP.md` describes Apple framework adoption opportunities.
+- `native/README.md` describes the current implementation and release lane.
+- Stitch should explore the destination UI, not recreate the old Three.js layout or the current Swift prototype one-for-one.
+
+## Stitch Project
+
+- Project title: `Oscillo Native macOS Design Lab`
+- Project ID: `2328505340539181137`
+- Project resource: `projects/2328505340539181137`
+- Design system asset: `assets/2124855500104295941`
+- Design system name: `Oscillo Native - Signal Foundry`
+
+Verification note: `list_design_systems` returns the asset above. `get_project` may show an empty `designTheme` even after the design-system asset is created.
+
+## Current Local MCP Status
+
+OffScript did not have a repo-local Stitch MCP JSON file to copy. It uses a repo-safe workflow document and a global Codex MCP config.
+
+Codex is configured globally with the Stitch remote MCP endpoint:
+
+```toml
+[mcp_servers.stitch]
+url = "https://stitch.googleapis.com/mcp"
+env_http_headers = { "X-Goog-Api-Key" = "STITCH_API_KEY" }
+```
+
+The key itself must stay outside this repository and outside checked-in config. Set it locally as `STITCH_API_KEY`.
+
+For terminal-launched Codex sessions:
+
+```sh
+export STITCH_API_KEY="..."
+```
+
+For the macOS desktop app, set it through launch services, then fully restart Codex:
+
+```sh
+launchctl setenv STITCH_API_KEY "..."
+```
+
+Do not commit local OAuth files, API keys, tokens, account files, downloaded credentials, or generated private config to this repository.
+
+## Stitch MCP Payload Note
+
+The Stitch design-system tools require a structured object even though some tool descriptions make `designSystem` look like a plain string.
+
+Working shape:
+
+```json
+{
+  "projectId": "2328505340539181137",
+  "designSystem": {
+    "displayName": "Oscillo Native - Signal Foundry",
+    "theme": {
+      "colorMode": "DARK",
+      "headlineFont": "SPACE_GROTESK",
+      "bodyFont": "INTER",
+      "labelFont": "SPACE_GROTESK",
+      "roundness": "ROUND_FOUR",
+      "customColor": "#21E6C1",
+      "colorVariant": "VIBRANT",
+      "overridePrimaryColor": "#21E6C1",
+      "overrideSecondaryColor": "#FF4D6D",
+      "overrideTertiaryColor": "#F8D66D",
+      "overrideNeutralColor": "#0B0D10",
+      "designMd": "..."
+    }
+  }
+}
+```
+
+After `create_design_system`, immediately call `update_design_system` with the returned asset name so the design system is displayed in the Stitch project.
+
+## Stitch Prompt Contract
+
+When creating or refining Oscillo screens in Stitch, attach or paste `native/DESIGN_DIRECTION.md` and use this framing:
+
+```text
+Use the attached Oscillo native design direction as the source of truth. Design a macOS audio-visual instrument called Oscillo, built in SwiftUI and Metal. The first screen is the instrument: a dominant live visual stage with compact native controls for audio source, sensitivity, scene mode, palette, quality, capture, presets, and update status. The style is Signal Foundry: dark performance surface, precise studio controls, luminous audio-reactive signal color, spectral grids, oscilloscope traces, and a tool-like macOS workflow. Do not copy the old Three.js composition literally. Avoid landing-page structure, generic SaaS dashboards, purple-blue gradient blobs, decorative bokeh, heavy glass everywhere, equal-weight cards, fake analytics widgets, and explanatory onboarding text inside the main instrument.
+```
+
+## What To Generate First
+
+Prioritize screens where visual hierarchy and interaction density matter most:
+
+1. Live instrument with dominant Metal visual stage, compact control rail, and visible update status.
+2. Audio input calibration with microphone, preview signal, levels, sensitivity, and noise floor controls.
+3. Scene and preset browser for tunnel, constellation, liquid surface, spectrogram stage, and spectral terrain modes.
+4. Capture/export queue for saved frames, short clips, and share-ready renders.
+5. Performance diagnostics with frame pacing, render quality, audio latency, and battery-aware behavior.
+6. Later iOS adaptation once the macOS instrument direction is stable.
+
+## Implementation Rules For Stitch Output
+
+- Treat Stitch output as direction, not production code.
+- Translate visual ideas into SwiftUI controls and Metal render states.
+- Keep the visual stage dominant; controls should frame the signal, not become the app.
+- Use native macOS behavior: menu commands, keyboard shortcuts, hover states, focus rings, window resizing, high contrast, and reduced motion.
+- Keep control dimensions stable so live meters, long input names, update copy, and hover states cannot resize the layout.
+- Prefer SF Pro and SF Mono in SwiftUI even if Stitch approximates with Space Grotesk and Inter.
+- Move repeated colors, spacing, and type roles into native design tokens before spreading them across views.
+- Do not add a marketing landing page or in-app explanatory text that describes the app's features.
+
+## Visual QA Checklist
+
+Before implementing a Stitch-inspired screen, verify:
+
+- The live visualizer remains the first-viewport focus.
+- Controls are compact, legible, and keyboard reachable.
+- Update status is visible without competing with performance controls.
+- Audio meters and labels do not overlap at small window sizes.
+- Text never depends on visualizer contrast.
+- Color is paired with labels, icons, meter position, or shape.
+- Reduce Motion keeps the signal readable with lower amplitude effects.
+- The design does not drift back into the pre-native Three.js layout unless the native app benefits from it.

--- a/docs/STITCH_WORKFLOW.md
+++ b/docs/STITCH_WORKFLOW.md
@@ -1,12 +1,12 @@
 # Oscillo Stitch Workflow
 
-Use Google Stitch as a visual exploration surface for the native Swift/macOS lane. The source of truth for product direction is `native/DESIGN_DIRECTION.md`; Stitch output is reference material, not production code.
+Use Google Stitch as a visual exploration surface for the native Swift/macOS lane. The source of truth for product direction is [`native/DESIGN_DIRECTION.md`](../native/DESIGN_DIRECTION.md); Stitch output is reference material, not production code.
 
 Important distinction:
 
-- `native/DESIGN_DIRECTION.md` describes the native product direction.
-- `native/APPLE_TECH_MAP.md` describes Apple framework adoption opportunities.
-- `native/README.md` describes the current implementation and release lane.
+- [`native/DESIGN_DIRECTION.md`](../native/DESIGN_DIRECTION.md) describes the native product direction.
+- [`native/APPLE_TECH_MAP.md`](../native/APPLE_TECH_MAP.md) describes Apple framework adoption opportunities.
+- [`native/README.md`](../native/README.md) describes the current implementation and release lane.
 - Stitch should explore the destination UI, not recreate the old Three.js layout or the current Swift prototype one-for-one.
 
 ## Stitch Project
@@ -21,7 +21,7 @@ Verification note: `list_design_systems` returns the asset above. `get_project` 
 
 ## Current Local MCP Status
 
-OffScript did not have a repo-local Stitch MCP JSON file to copy. It uses a repo-safe workflow document and a global Codex MCP config.
+Oscillo does not have a repo-local Stitch MCP JSON file to copy. It uses a repo-safe workflow document and a global Codex MCP config.
 
 Codex is configured globally with the Stitch remote MCP endpoint:
 
@@ -39,7 +39,7 @@ For terminal-launched Codex sessions:
 export STITCH_API_KEY="..."
 ```
 
-For the macOS desktop app, set it through launch services, then fully restart Codex:
+For the macOS desktop app, set it via `launchctl` for apps started by `launchd`, then fully restart Codex so it picks up the new environment:
 
 ```sh
 launchctl setenv STITCH_API_KEY "..."
@@ -80,7 +80,7 @@ After `create_design_system`, immediately call `update_design_system` with the r
 
 ## Stitch Prompt Contract
 
-When creating or refining Oscillo screens in Stitch, attach or paste `native/DESIGN_DIRECTION.md` and use this framing:
+When creating or refining Oscillo screens in Stitch, attach or paste [`native/DESIGN_DIRECTION.md`](../native/DESIGN_DIRECTION.md) and use this framing:
 
 ```text
 Use the attached Oscillo native design direction as the source of truth. Design a macOS audio-visual instrument called Oscillo, built in SwiftUI and Metal. The first screen is the instrument: a dominant live visual stage with compact native controls for audio source, sensitivity, scene mode, palette, quality, capture, presets, and update status. The style is Signal Foundry: dark performance surface, precise studio controls, luminous audio-reactive signal color, spectral grids, oscilloscope traces, and a tool-like macOS workflow. Do not copy the old Three.js composition literally. Avoid landing-page structure, generic SaaS dashboards, purple-blue gradient blobs, decorative bokeh, heavy glass everywhere, equal-weight cards, fake analytics widgets, and explanatory onboarding text inside the main instrument.

--- a/native/DESIGN_DIRECTION.md
+++ b/native/DESIGN_DIRECTION.md
@@ -4,6 +4,8 @@ The Swift rewrite is not a strict port of the pre-native Three.js experiment.
 
 The web app is useful source material for the domain: audio reactivity, visual synthesis, musical controls, and exploratory play. It should not be treated as the final layout, visual language, interaction model, or feature checklist for the native app.
 
+Google Stitch exploration for this direction lives in `../docs/STITCH_WORKFLOW.md`.
+
 ## Product North Star
 
 Oscillo Native should feel like a living instrument for sound-driven light.

--- a/native/DESIGN_DIRECTION.md
+++ b/native/DESIGN_DIRECTION.md
@@ -4,7 +4,7 @@ The Swift rewrite is not a strict port of the pre-native Three.js experiment.
 
 The web app is useful source material for the domain: audio reactivity, visual synthesis, musical controls, and exploratory play. It should not be treated as the final layout, visual language, interaction model, or feature checklist for the native app.
 
-Google Stitch exploration for this direction lives in `../docs/STITCH_WORKFLOW.md`.
+Google Stitch exploration for this direction lives in [`docs/STITCH_WORKFLOW.md`](../docs/STITCH_WORKFLOW.md).
 
 ## Product North Star
 

--- a/native/README.md
+++ b/native/README.md
@@ -10,6 +10,7 @@ The current slice is intentionally separate from the existing Next/Three.js app.
 - `APPLE_TECH_MAP.md`: current Apple framework research and adoption plan.
 - `DESIGN_DIRECTION.md`: native creative direction and non-parity guidance.
 - `UPDATES.md`: GitHub release update channel and secure OTA path.
+- `../docs/STITCH_WORKFLOW.md`: Google Stitch project, MCP setup notes, and native visual exploration workflow.
 
 ## Requirements
 
@@ -60,6 +61,8 @@ Native release builds are published by `.github/workflows/native-release.yml` us
 See `UPDATES.md` for the current GitHub Releases update channel and the secure Sparkle OTA install path.
 
 See `DESIGN_DIRECTION.md` before making visual or interaction decisions. The Swift app is allowed to diverge from the old Three.js experiment.
+
+Use `../docs/STITCH_WORKFLOW.md` when exploring new native screen directions in Google Stitch.
 
 ## Current Scope
 

--- a/native/README.md
+++ b/native/README.md
@@ -10,7 +10,7 @@ The current slice is intentionally separate from the existing Next/Three.js app.
 - `APPLE_TECH_MAP.md`: current Apple framework research and adoption plan.
 - `DESIGN_DIRECTION.md`: native creative direction and non-parity guidance.
 - `UPDATES.md`: GitHub release update channel and secure OTA path.
-- `../docs/STITCH_WORKFLOW.md`: Google Stitch project, MCP setup notes, and native visual exploration workflow.
+- [`docs/STITCH_WORKFLOW.md`](../docs/STITCH_WORKFLOW.md): Google Stitch project, MCP setup notes, and native visual exploration workflow.
 
 ## Requirements
 
@@ -62,7 +62,7 @@ See `UPDATES.md` for the current GitHub Releases update channel and the secure S
 
 See `DESIGN_DIRECTION.md` before making visual or interaction decisions. The Swift app is allowed to diverge from the old Three.js experiment.
 
-Use `../docs/STITCH_WORKFLOW.md` when exploring new native screen directions in Google Stitch.
+Use [`docs/STITCH_WORKFLOW.md`](../docs/STITCH_WORKFLOW.md) when exploring new native screen directions in Google Stitch.
 
 ## Current Scope
 


### PR DESCRIPTION
## Summary\n- add an Oscillo-specific Google Stitch workflow doc\n- record the live Stitch project/design-system IDs and the repo-safe MCP setup pattern\n- link the native README and design direction to the Stitch workflow\n\nCloses #430\n\n## Verification\n- git diff --check\n- staged secret-pattern scan for credentials; only placeholder STITCH_API_KEY="..." was present\n- verified Stitch MCP with list_design_systems for project 2328505340539181137