### PR TITLE
feat(native): add Signal Foundry instrument UI

### DIFF
--- a/docs/STITCH_WORKFLOW.md
+++ b/docs/STITCH_WORKFLOW.md
@@ -19,6 +19,20 @@ Important distinction:
 
 Verification note: `list_design_systems` returns the asset above. `get_project` may show an empty `designTheme` even after the design-system asset is created.
 
+Generated concept screens:
+
+- `Oscillo Native - Instrument View`
+  - Screen ID: `0f6bee9346494223b495eeb07869b229`
+  - Screen resource: `projects/2328505340539181137/screens/0f6bee9346494223b495eeb07869b229`
+- `Performance Cockpit - Variation 1`
+  - Screen ID: `01f93dcb49f94f819b9dabac88c968d4`
+  - Screen resource: `projects/2328505340539181137/screens/01f93dcb49f94f819b9dabac88c968d4`
+- Reimagined variants from `Oscillo Native - Instrument View`
+  - `41b5cd25345747a88a5b8261ce36473b`: left instrument spine / performance cockpit
+  - `f55f61e2a73945a5bbb864217e54ea02`: bottom-console live visual rig
+  - `85576dc0e45441dcbf0e1ff7502fcf5e`: floating HUD over full-bleed spectral terrain
+  - `95bcdf361bd44308b06f97131b8c8188`: compact spectral workbench
+
 ## Current Local MCP Status
 
 Oscillo does not have a repo-local Stitch MCP JSON file to copy. It uses a repo-safe workflow document and a global Codex MCP config.
@@ -77,6 +91,25 @@ Working shape:
 ```
 
 After `create_design_system`, immediately call `update_design_system` with the returned asset name so the design system is displayed in the Stitch project.
+
+Variant generation uses an object-shaped `variantOptions` payload, despite some client schemas making this look string-like:
+
+```json
+{
+  "projectId": "2328505340539181137",
+  "selectedScreenIds": ["0f6bee9346494223b495eeb07869b229"],
+  "deviceType": "DESKTOP",
+  "modelId": "GEMINI_3_PRO",
+  "variantOptions": {
+    "variantCount": 4,
+    "creativeRange": "REIMAGINE",
+    "aspects": ["LAYOUT", "COLOR_SCHEME", "TEXT_FONT", "TEXT_CONTENT"]
+  },
+  "prompt": "Generate four divergent variants..."
+}
+```
+
+Documented `creativeRange` values are `REFINE`, `EXPLORE`, and `REIMAGINE`. Documented `aspects` values are `LAYOUT`, `COLOR_SCHEME`, `IMAGES`, `TEXT_FONT`, and `TEXT_CONTENT`.
 
 ## Stitch Prompt Contract
 

--- a/native/AppBundle/Info.plist
+++ b/native/AppBundle/Info.plist
@@ -17,9 +17,9 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>0.1.5</string>
+	<string>0.1.6</string>
 	<key>CFBundleVersion</key>
-	<string>6</string>
+	<string>7</string>
 	<key>LSApplicationCategoryType</key>
 	<string>public.app-category.music</string>
 	<key>LSMinimumSystemVersion</key>

--- a/native/DESIGN_DIRECTION.md
+++ b/native/DESIGN_DIRECTION.md
@@ -12,6 +12,14 @@ Oscillo Native should feel like a living instrument for sound-driven light.
 
 It should be immediate enough to open on a MacBook Pro and play with in seconds, but deep enough that each control changes the character of the scene. The app should feel native to Apple platforms: fast, tactile, precise, and visually rich without copying a web HUD.
 
+## Operating Definition
+
+Oscillo is a real-time creative instrument where audio analysis, visual synthesis, and performance controls are one playable surface.
+
+It should not behave like a passive visualizer, a media player, a DAW clone, a SaaS dashboard, or a marketing site. The native app should open directly into an instrument state: preview or microphone signal is available, the Metal scene is alive, and compact controls let the user shape how sound becomes motion, color, topology, and spatial behavior.
+
+The pre-Swift app defines the domain more than the destination. Its important ideas are audio reactivity, interactive 3D music play, AI composition potential, spatial rendering, and collaborative jam-session ambition. The Swift app should grow those ideas through Apple-native tools and interaction patterns instead of recreating the web layout or every old panel.
+
 ## Creative Principles
 
 - Prefer native interaction patterns over web parity.
@@ -19,6 +27,7 @@ It should be immediate enough to open on a MacBook Pro and play with in seconds,
 - Make the first screen the instrument, not an explanatory landing page.
 - Keep controls compact and inspectable; the scene should own most of the window.
 - Use Metal for visual identity, not just as a Three.js replacement.
+- Do not expose controls that imply unfinished features work; represent future capture, export, AI, spatial, and collaboration features only when there is a real implementation path.
 - Design macOS first for testing and iteration, but avoid choices that would make iOS feel bolted on later.
 - Treat Apple frameworks as creative material: Core Haptics, AVAudioEnvironmentNode, MetalFX, Sound Analysis, Core ML, Foundation Models, SwiftData, App Intents, and SharePlay can all become product features when they serve the experience.
 

--- a/native/Sources/OscilloCore/SceneSettings.swift
+++ b/native/Sources/OscilloCore/SceneSettings.swift
@@ -35,29 +35,88 @@ public enum ScenePalette: String, CaseIterable, Equatable, Identifiable, Sendabl
     }
 }
 
+public enum SceneMode: String, CaseIterable, Equatable, Identifiable, Sendable {
+    case spectralTerrain
+    case tunnel
+    case constellation
+    case liquidSurface
+    case spectrogramStage
+
+    public var id: String { rawValue }
+
+    public var displayName: String {
+        switch self {
+        case .spectralTerrain:
+            "Spectral Terrain"
+        case .tunnel:
+            "Tunnel"
+        case .constellation:
+            "Constellation"
+        case .liquidSurface:
+            "Liquid Surface"
+        case .spectrogramStage:
+            "Spectrogram Stage"
+        }
+    }
+
+    public var shortName: String {
+        switch self {
+        case .spectralTerrain:
+            "Terrain"
+        case .tunnel:
+            "Tunnel"
+        case .constellation:
+            "Stars"
+        case .liquidSurface:
+            "Liquid"
+        case .spectrogramStage:
+            "Spectrum"
+        }
+    }
+
+    public var uniformIndex: Int32 {
+        switch self {
+        case .spectralTerrain:
+            0
+        case .tunnel:
+            1
+        case .constellation:
+            2
+        case .liquidSurface:
+            3
+        case .spectrogramStage:
+            4
+        }
+    }
+}
+
 public struct SceneSettings: Equatable, Sendable {
     public var visualGain: Float
     public var particleDensity: Float
     public var previewTempo: Float
     public var palette: ScenePalette
+    public var sceneMode: SceneMode
 
     public init(
         visualGain: Float,
         particleDensity: Float,
         previewTempo: Float,
-        palette: ScenePalette
+        palette: ScenePalette,
+        sceneMode: SceneMode
     ) {
         self.visualGain = visualGain.clamped(to: 0.25...2.0)
         self.particleDensity = particleDensity.clamped(to: 0.15...1.5)
         self.previewTempo = previewTempo.clamped(to: 0.5...2.0)
         self.palette = palette
+        self.sceneMode = sceneMode
     }
 
     public static let standard = SceneSettings(
         visualGain: 1.0,
         particleDensity: 0.9,
         previewTempo: 1.0,
-        palette: .neon
+        palette: .neon,
+        sceneMode: .spectralTerrain
     )
 }
 

--- a/native/Sources/OscilloMac/ContentView.swift
+++ b/native/Sources/OscilloMac/ContentView.swift
@@ -7,7 +7,7 @@ struct ContentView: View {
     @StateObject private var updateController = UpdateController()
 
     var body: some View {
-        ZStack(alignment: .topLeading) {
+        ZStack {
             OscilloMetalSurface(
                 featureStore: audioEngine.featureStore,
                 settingsStore: sceneController.settingsStore,
@@ -15,13 +15,43 @@ struct ContentView: View {
             )
             .ignoresSafeArea()
 
-            ControlPanel(
-                audioEngine: audioEngine,
-                sceneController: sceneController,
-                updateController: updateController
+            LinearGradient(
+                colors: [
+                    SignalTheme.voidBlack.opacity(0.72),
+                    .clear,
+                    SignalTheme.voidBlack.opacity(0.54)
+                ],
+                startPoint: .leading,
+                endPoint: .trailing
             )
+            .allowsHitTesting(false)
+            .ignoresSafeArea()
+
+            HStack(alignment: .top) {
+                InstrumentSpine(
+                    audioEngine: audioEngine,
+                    sceneController: sceneController,
+                    updateController: updateController
+                )
                 .padding(18)
+
+                Spacer(minLength: 16)
+
+                SceneStatusDeck(
+                    sceneController: sceneController,
+                    updateController: updateController
+                )
+                .padding(18)
+            }
+
+            VStack {
+                Spacer()
+                BottomSignalConsole(audioEngine: audioEngine, sceneController: sceneController)
+                    .padding(.horizontal, 18)
+                    .padding(.bottom, 18)
+            }
         }
+        .background(SignalTheme.voidBlack)
         .task {
             audioEngine.startPreview()
             updateController.checkAutomaticallyOnLaunch()
@@ -29,130 +59,246 @@ struct ContentView: View {
     }
 }
 
-private struct ControlPanel: View {
+private struct InstrumentSpine: View {
     @ObservedObject var audioEngine: LiveAudioEngine
     @ObservedObject var sceneController: SceneController
     @ObservedObject var updateController: UpdateController
     private let buildMetadata = AppBuildMetadata(bundleInfo: Bundle.main.infoDictionary ?? [:])
 
     var body: some View {
-        VStack(alignment: .leading, spacing: 16) {
-            VStack(alignment: .leading, spacing: 4) {
+        VStack(alignment: .leading, spacing: 14) {
+            VStack(alignment: .leading, spacing: 6) {
                 HStack(alignment: .firstTextBaseline) {
-                    Text("Oscillo")
-                        .font(.system(size: 20, weight: .semibold, design: .rounded))
-                    Spacer(minLength: 10)
-                    Text(buildMetadata.visibleBuildMarker)
-                        .font(.caption2.monospacedDigit())
-                        .foregroundStyle(.secondary)
+                    Text("OSCILLO")
+                        .font(.system(size: 22, weight: .black, design: .rounded))
+                        .foregroundStyle(SignalTheme.softWhite)
+                    Spacer(minLength: 12)
+                    Text(buildMetadata.visibleBuildMarker.uppercased())
+                        .font(.system(size: 10, weight: .semibold, design: .monospaced))
+                        .foregroundStyle(SignalTheme.mutedSteel)
                 }
+
+                Text(sceneController.settings.sceneMode.displayName.uppercased())
+                    .font(.system(size: 11, weight: .semibold, design: .monospaced))
+                    .foregroundStyle(SignalTheme.signalTeal)
 
                 Text(audioEngine.statusMessage)
-                    .font(.caption)
-                    .foregroundStyle(.secondary)
+                    .font(.system(size: 11, weight: .medium, design: .monospaced))
+                    .foregroundStyle(SignalTheme.mutedSteel)
+                    .lineLimit(2)
             }
-
-            HStack(spacing: 10) {
-                Button(audioEngine.isRunning ? "Stop Input" : "Use Microphone") {
-                    if audioEngine.isRunning {
-                        audioEngine.stopMicrophone()
-                    } else {
-                        audioEngine.startMicrophone()
-                    }
-                }
-                .buttonStyle(.borderedProminent)
-
-                Button(audioEngine.isPreviewing ? "Pause Preview" : "Preview") {
-                    if audioEngine.isPreviewing {
-                        audioEngine.stopPreview(resetFeatures: true)
-                    } else {
-                        audioEngine.startPreview()
-                    }
-                }
-                .buttonStyle(.bordered)
-            }
-
-            Picker("Palette", selection: Binding(
-                get: { sceneController.settings.palette },
-                set: { sceneController.setPalette($0) }
-            )) {
-                ForEach(ScenePalette.allCases) { palette in
-                    Text(palette.displayName).tag(palette)
-                }
-            }
-            .pickerStyle(.segmented)
-
-            ControlSlider(
-                title: "Intensity",
-                value: Binding(
-                    get: { sceneController.settings.visualGain },
-                    set: { sceneController.setVisualGain($0) }
-                ),
-                range: 0.25...2.0
-            )
-
-            ControlSlider(
-                title: "Particles",
-                value: Binding(
-                    get: { sceneController.settings.particleDensity },
-                    set: { sceneController.setParticleDensity($0) }
-                ),
-                range: 0.15...1.5
-            )
-
-            ControlSlider(
-                title: "Preview Tempo",
-                value: Binding(
-                    get: { sceneController.settings.previewTempo },
-                    set: { sceneController.setPreviewTempo($0) }
-                ),
-                range: 0.5...2.0
-            )
 
             Divider()
-                .overlay(.white.opacity(0.16))
-
-            FeatureMeter(title: "Level", value: audioEngine.features.volume)
-            FeatureMeter(title: "Bass", value: audioEngine.features.bassEnergy)
-            FeatureMeter(title: "Mid", value: audioEngine.features.midEnergy)
-            FeatureMeter(title: "Treble", value: audioEngine.features.trebleEnergy)
-
-            Divider()
-                .overlay(.white.opacity(0.16))
+                .overlay(SignalTheme.gridLine.opacity(0.9))
 
             VStack(alignment: .leading, spacing: 8) {
-                HStack(spacing: 10) {
-                    Button(updateController.isChecking ? "Checking..." : "Check Updates") {
-                        updateController.checkNow()
-                    }
-                    .disabled(updateController.isChecking)
+                ModuleLabel("INPUT")
+                HStack(spacing: 8) {
+                    SignalActionButton(
+                        title: audioEngine.isRunning ? "STOP" : "MIC",
+                        systemImage: audioEngine.isRunning ? "stop.fill" : "waveform",
+                        isActive: audioEngine.isRunning,
+                        action: toggleMicrophone
+                    )
 
-                    Button("Open Release") {
-                        updateController.openReleasePage()
-                    }
-                    .disabled(updateController.releaseURL == nil)
+                    SignalActionButton(
+                        title: audioEngine.isPreviewing ? "PAUSE" : "PREVIEW",
+                        systemImage: audioEngine.isPreviewing ? "pause.fill" : "play.fill",
+                        isActive: audioEngine.isPreviewing,
+                        action: togglePreview
+                    )
                 }
-
-                Text(updateController.statusText)
-                    .font(.caption)
-                    .foregroundStyle(.secondary)
-                    .fixedSize(horizontal: false, vertical: true)
             }
+
+            VStack(alignment: .leading, spacing: 8) {
+                ModuleLabel("SCENE")
+                LazyVGrid(columns: [
+                    GridItem(.flexible(), spacing: 6),
+                    GridItem(.flexible(), spacing: 6)
+                ], spacing: 6) {
+                    ForEach(SceneMode.allCases) { mode in
+                        SceneModePill(
+                            mode: mode,
+                            isSelected: mode == sceneController.settings.sceneMode
+                        ) {
+                            sceneController.setSceneMode(mode)
+                        }
+                    }
+                }
+            }
+
+            VStack(alignment: .leading, spacing: 8) {
+                ModuleLabel("PALETTE")
+                Picker("Palette", selection: Binding(
+                    get: { sceneController.settings.palette },
+                    set: { sceneController.setPalette($0) }
+                )) {
+                    ForEach(ScenePalette.allCases) { palette in
+                        Text(palette.displayName).tag(palette)
+                    }
+                }
+                .pickerStyle(.segmented)
+                .controlSize(.small)
+            }
+
+            VStack(spacing: 12) {
+                SignalSlider(
+                    title: "INTENSITY",
+                    value: Binding(
+                        get: { sceneController.settings.visualGain },
+                        set: { sceneController.setVisualGain($0) }
+                    ),
+                    range: 0.25...2.0,
+                    accent: SignalTheme.signalTeal
+                )
+
+                SignalSlider(
+                    title: "PARTICLES",
+                    value: Binding(
+                        get: { sceneController.settings.particleDensity },
+                        set: { sceneController.setParticleDensity($0) }
+                    ),
+                    range: 0.15...1.5,
+                    accent: SignalTheme.transientCoral
+                )
+
+                SignalSlider(
+                    title: "TEMPO",
+                    value: Binding(
+                        get: { sceneController.settings.previewTempo },
+                        set: { sceneController.setPreviewTempo($0) }
+                    ),
+                    range: 0.5...2.0,
+                    accent: SignalTheme.warmPeak
+                )
+            }
+
+            Spacer(minLength: 4)
+
+            UpdateRackModule(updateController: updateController)
         }
-        .padding(18)
-        .frame(width: 312, alignment: .leading)
-        .background(.black.opacity(0.58), in: RoundedRectangle(cornerRadius: 8))
-        .overlay(
-            RoundedRectangle(cornerRadius: 8)
-                .stroke(.white.opacity(0.14), lineWidth: 1)
-        )
+        .padding(16)
+        .frame(width: 302, alignment: .topLeading)
+        .frame(minHeight: 620, alignment: .topLeading)
+        .signalPanel(cornerRadius: 10)
+    }
+
+    private func toggleMicrophone() {
+        if audioEngine.isRunning {
+            audioEngine.stopMicrophone()
+        } else {
+            audioEngine.startMicrophone()
+        }
+    }
+
+    private func togglePreview() {
+        if audioEngine.isPreviewing {
+            audioEngine.stopPreview(resetFeatures: true)
+        } else {
+            audioEngine.startPreview()
+        }
     }
 }
 
-private struct ControlSlider: View {
+private struct SceneStatusDeck: View {
+    @ObservedObject var sceneController: SceneController
+    @ObservedObject var updateController: UpdateController
+
+    var body: some View {
+        VStack(alignment: .trailing, spacing: 10) {
+            HStack(spacing: 8) {
+                SignalBadge(sceneController.settings.sceneMode.displayName)
+                SignalBadge("METAL LIVE")
+                SignalBadge(updateController.isChecking ? "OTA CHECK" : "OTA READY")
+            }
+
+            HStack(spacing: 8) {
+                Button {
+                    updateController.checkNow()
+                } label: {
+                    Label(updateController.isChecking ? "Checking" : "Check", systemImage: "arrow.triangle.2.circlepath")
+                }
+                .disabled(updateController.isChecking)
+
+                Button {
+                    updateController.openReleasePage()
+                } label: {
+                    Label("Release", systemImage: "arrow.up.forward.app")
+                }
+                .disabled(updateController.releaseURL == nil)
+            }
+            .buttonStyle(.bordered)
+            .controlSize(.small)
+
+            Text(updateController.statusText)
+                .font(.system(size: 11, weight: .medium, design: .monospaced))
+                .foregroundStyle(SignalTheme.mutedSteel)
+                .multilineTextAlignment(.trailing)
+                .lineLimit(2)
+                .frame(maxWidth: 320, alignment: .trailing)
+        }
+        .padding(12)
+        .signalPanel(cornerRadius: 10)
+    }
+}
+
+private struct BottomSignalConsole: View {
+    @ObservedObject var audioEngine: LiveAudioEngine
+    @ObservedObject var sceneController: SceneController
+
+    var body: some View {
+        HStack(alignment: .center, spacing: 18) {
+            VStack(alignment: .leading, spacing: 6) {
+                Text("SIGNAL CONSOLE")
+                    .font(.system(size: 11, weight: .bold, design: .monospaced))
+                    .foregroundStyle(SignalTheme.signalTeal)
+                Text(sceneController.settings.sceneMode.displayName)
+                    .font(.system(size: 18, weight: .semibold, design: .rounded))
+                    .foregroundStyle(SignalTheme.softWhite)
+            }
+            .frame(width: 190, alignment: .leading)
+
+            HStack(spacing: 12) {
+                HardwareMeter(title: "LVL", value: audioEngine.features.volume, accent: SignalTheme.meterGreen)
+                HardwareMeter(title: "BASS", value: audioEngine.features.bassEnergy, accent: SignalTheme.signalTeal)
+                HardwareMeter(title: "MID", value: audioEngine.features.midEnergy, accent: SignalTheme.oscillatorCyan)
+                HardwareMeter(title: "HI", value: audioEngine.features.trebleEnergy, accent: SignalTheme.warmPeak)
+            }
+
+            Divider()
+                .frame(height: 62)
+                .overlay(SignalTheme.gridLine)
+
+            HStack(spacing: 8) {
+                ForEach(SceneMode.allCases) { mode in
+                    SceneChip(
+                        mode: mode,
+                        isSelected: mode == sceneController.settings.sceneMode
+                    ) {
+                        sceneController.setSceneMode(mode)
+                    }
+                }
+            }
+
+            Spacer(minLength: 12)
+
+            HStack(spacing: 8) {
+                SignalBadge("QUALITY AUTO")
+                SignalBadge("OUTPUT LIVE")
+            }
+        }
+        .padding(.horizontal, 16)
+        .padding(.vertical, 12)
+        .frame(maxWidth: .infinity, minHeight: 96)
+        .signalPanel(cornerRadius: 12)
+    }
+}
+
+private struct SignalSlider: View {
     let title: String
     @Binding var value: Float
     let range: ClosedRange<Float>
+    let accent: Color
 
     var body: some View {
         VStack(alignment: .leading, spacing: 6) {
@@ -161,9 +307,22 @@ private struct ControlSlider: View {
                 Spacer()
                 Text(value.formatted(.number.precision(.fractionLength(2))))
                     .monospacedDigit()
-                    .foregroundStyle(.secondary)
             }
-            .font(.caption)
+            .font(.system(size: 10, weight: .bold, design: .monospaced))
+            .foregroundStyle(SignalTheme.mutedSteel)
+
+            GeometryReader { proxy in
+                ZStack(alignment: .leading) {
+                    RoundedRectangle(cornerRadius: 2)
+                        .fill(SignalTheme.raisedGraphite)
+                    RoundedRectangle(cornerRadius: 2)
+                        .fill(accent)
+                        .frame(width: proxy.size.width * normalizedValue)
+                    RoundedRectangle(cornerRadius: 2)
+                        .stroke(SignalTheme.gridLine, lineWidth: 1)
+                }
+            }
+            .frame(height: 6)
 
             Slider(
                 value: Binding(
@@ -172,40 +331,225 @@ private struct ControlSlider: View {
                 ),
                 in: Double(range.lowerBound)...Double(range.upperBound)
             )
+            .controlSize(.small)
+            .tint(accent)
         }
-        .foregroundStyle(.white)
+    }
+
+    private var normalizedValue: CGFloat {
+        let span = range.upperBound - range.lowerBound
+        guard span > 0 else { return 0 }
+        return CGFloat((value - range.lowerBound) / span)
     }
 }
 
-private struct FeatureMeter: View {
+private struct HardwareMeter: View {
     let title: String
     let value: Float
+    let accent: Color
 
     var body: some View {
-        VStack(alignment: .leading, spacing: 5) {
-            HStack {
-                Text(title)
-                Spacer()
-                Text(value.formatted(.number.precision(.fractionLength(2))))
-                    .monospacedDigit()
+        VStack(spacing: 5) {
+            HStack(spacing: 3) {
+                ForEach(0..<12, id: \.self) { index in
+                    RoundedRectangle(cornerRadius: 1)
+                        .fill(segmentColor(index: index))
+                        .frame(width: 7, height: 26)
+                }
             }
-            .font(.caption)
 
-            GeometryReader { proxy in
-                RoundedRectangle(cornerRadius: 2)
-                    .fill(.white.opacity(0.14))
-                    .overlay(alignment: .leading) {
-                        RoundedRectangle(cornerRadius: 2)
-                            .fill(LinearGradient(
-                                colors: [.cyan, .pink],
-                                startPoint: .leading,
-                                endPoint: .trailing
-                            ))
-                            .frame(width: proxy.size.width * CGFloat(min(max(value, 0), 1)))
-                    }
+            HStack(spacing: 5) {
+                Text(title)
+                    .font(.system(size: 10, weight: .bold, design: .monospaced))
+                Text(value.formatted(.number.precision(.fractionLength(2))))
+                    .font(.system(size: 10, weight: .medium, design: .monospaced))
+                    .monospacedDigit()
+                    .foregroundStyle(SignalTheme.mutedSteel)
             }
-            .frame(height: 5)
         }
-        .foregroundStyle(.white)
+        .frame(width: 108)
+        .foregroundStyle(SignalTheme.softWhite)
     }
+
+    private func segmentColor(index: Int) -> Color {
+        let normalized = CGFloat(min(max(value, 0), 1))
+        let threshold = CGFloat(index + 1) / 12.0
+        guard normalized >= threshold else {
+            return SignalTheme.panelCarbon
+        }
+        if index > 9 {
+            return SignalTheme.transientCoral
+        }
+        if index > 7 {
+            return SignalTheme.warmPeak
+        }
+        return accent
+    }
+}
+
+private struct SceneModePill: View {
+    let mode: SceneMode
+    let isSelected: Bool
+    let action: () -> Void
+
+    var body: some View {
+        Button(action: action) {
+            Text(mode.shortName.uppercased())
+                .font(.system(size: 10, weight: .bold, design: .monospaced))
+                .frame(maxWidth: .infinity)
+                .padding(.vertical, 7)
+        }
+        .buttonStyle(.plain)
+        .foregroundStyle(isSelected ? SignalTheme.voidBlack : SignalTheme.mutedSteel)
+        .background(isSelected ? SignalTheme.signalTeal : SignalTheme.raisedGraphite, in: RoundedRectangle(cornerRadius: 5))
+        .overlay(
+            RoundedRectangle(cornerRadius: 5)
+                .stroke(isSelected ? SignalTheme.signalTeal : SignalTheme.gridLine, lineWidth: 1)
+        )
+    }
+}
+
+private struct SceneChip: View {
+    let mode: SceneMode
+    let isSelected: Bool
+    let action: () -> Void
+
+    var body: some View {
+        Button(action: action) {
+            Text(mode.shortName)
+                .font(.system(size: 11, weight: .semibold, design: .monospaced))
+                .padding(.horizontal, 10)
+                .padding(.vertical, 7)
+        }
+        .buttonStyle(.plain)
+        .foregroundStyle(isSelected ? SignalTheme.voidBlack : SignalTheme.softWhite)
+        .background(isSelected ? SignalTheme.warmPeak : SignalTheme.panelCarbon, in: RoundedRectangle(cornerRadius: 6))
+        .overlay(
+            RoundedRectangle(cornerRadius: 6)
+                .stroke(isSelected ? SignalTheme.warmPeak : SignalTheme.gridLine, lineWidth: 1)
+        )
+    }
+}
+
+private struct SignalActionButton: View {
+    let title: String
+    let systemImage: String
+    let isActive: Bool
+    let action: () -> Void
+
+    var body: some View {
+        Button(action: action) {
+            Label(title, systemImage: systemImage)
+                .font(.system(size: 11, weight: .bold, design: .monospaced))
+                .labelStyle(.titleAndIcon)
+                .frame(maxWidth: .infinity)
+                .padding(.vertical, 8)
+                .padding(.horizontal, 9)
+        }
+        .buttonStyle(.plain)
+        .foregroundStyle(isActive ? SignalTheme.voidBlack : SignalTheme.softWhite)
+        .background(isActive ? SignalTheme.signalTeal : SignalTheme.raisedGraphite, in: RoundedRectangle(cornerRadius: 7))
+        .overlay(
+            RoundedRectangle(cornerRadius: 7)
+                .stroke(isActive ? SignalTheme.signalTeal : SignalTheme.gridLine, lineWidth: 1)
+        )
+    }
+}
+
+private struct UpdateRackModule: View {
+    @ObservedObject var updateController: UpdateController
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            ModuleLabel("RELEASE")
+            HStack(spacing: 8) {
+                SignalActionButton(
+                    title: updateController.isChecking ? "CHECKING" : "CHECK",
+                    systemImage: "arrow.triangle.2.circlepath",
+                    isActive: updateController.isChecking
+                ) {
+                    updateController.checkNow()
+                }
+                .disabled(updateController.isChecking)
+
+                SignalActionButton(
+                    title: "OPEN",
+                    systemImage: "arrow.up.forward.app",
+                    isActive: updateController.releaseURL != nil
+                ) {
+                    updateController.openReleasePage()
+                }
+                .disabled(updateController.releaseURL == nil)
+            }
+
+            Text(updateController.statusText)
+                .font(.system(size: 10, weight: .medium, design: .monospaced))
+                .foregroundStyle(SignalTheme.mutedSteel)
+                .fixedSize(horizontal: false, vertical: true)
+        }
+    }
+}
+
+private struct SignalBadge: View {
+    let text: String
+
+    init(_ text: String) {
+        self.text = text
+    }
+
+    var body: some View {
+        Text(text.uppercased())
+            .font(.system(size: 10, weight: .bold, design: .monospaced))
+            .foregroundStyle(SignalTheme.signalTeal)
+            .padding(.horizontal, 9)
+            .padding(.vertical, 5)
+            .background(SignalTheme.panelCarbon, in: RoundedRectangle(cornerRadius: 5))
+            .overlay(
+                RoundedRectangle(cornerRadius: 5)
+                    .stroke(SignalTheme.gridLine, lineWidth: 1)
+            )
+    }
+}
+
+private struct ModuleLabel: View {
+    let title: String
+
+    init(_ title: String) {
+        self.title = title
+    }
+
+    var body: some View {
+        Text(title)
+            .font(.system(size: 10, weight: .bold, design: .monospaced))
+            .foregroundStyle(SignalTheme.mutedSteel)
+            .tracking(1.2)
+    }
+}
+
+private extension View {
+    func signalPanel(cornerRadius: CGFloat) -> some View {
+        background(
+            SignalTheme.panelCarbon.opacity(0.82),
+            in: RoundedRectangle(cornerRadius: cornerRadius, style: .continuous)
+        )
+        .overlay(
+            RoundedRectangle(cornerRadius: cornerRadius, style: .continuous)
+                .stroke(SignalTheme.gridLine.opacity(0.92), lineWidth: 1)
+        )
+        .shadow(color: SignalTheme.signalTeal.opacity(0.12), radius: 28, x: 0, y: 18)
+    }
+}
+
+private enum SignalTheme {
+    static let voidBlack = Color(red: 0.02, green: 0.025, blue: 0.035)
+    static let panelCarbon = Color(red: 0.045, green: 0.052, blue: 0.065)
+    static let raisedGraphite = Color(red: 0.078, green: 0.094, blue: 0.122)
+    static let gridLine = Color(red: 0.18, green: 0.23, blue: 0.28)
+    static let signalTeal = Color(red: 0.13, green: 0.90, blue: 0.76)
+    static let oscillatorCyan = Color(red: 0.22, green: 0.74, blue: 0.97)
+    static let transientCoral = Color(red: 1.0, green: 0.30, blue: 0.43)
+    static let warmPeak = Color(red: 0.97, green: 0.84, blue: 0.43)
+    static let meterGreen = Color(red: 0.49, green: 1.0, blue: 0.42)
+    static let softWhite = Color(red: 0.95, green: 0.97, blue: 0.98)
+    static let mutedSteel = Color(red: 0.60, green: 0.66, blue: 0.71)
 }

--- a/native/Sources/OscilloMac/MetalShaderSource.swift
+++ b/native/Sources/OscilloMac/MetalShaderSource.swift
@@ -17,6 +17,7 @@ enum MetalShaderSource {
         float visualGain;
         float particleDensity;
         int paletteIndex;
+        int sceneModeIndex;
         float padding;
         float2 resolution;
     };
@@ -82,48 +83,192 @@ enum MetalShaderSource {
         return smoothstep(size, 0.0, d);
     }
 
+    static float terrainLine(float2 p, float y, float width) {
+        return smoothstep(width, 0.0, abs(p.y - y));
+    }
+
+    static float3 terrainStage(float2 p,
+                               float2 uv,
+                               float time,
+                               float audio,
+                               float density,
+                               float3 low,
+                               float3 mid,
+                               float3 high,
+                               float bass,
+                               float mids,
+                               float treble) {
+        float grid = 0.0;
+        float2 gp = abs(fract((p + float2(0.0, time * 0.035)) * float2(7.0, 5.0)) - 0.5);
+        grid += smoothstep(0.018, 0.0, gp.x) * 0.16;
+        grid += smoothstep(0.014, 0.0, gp.y) * 0.12;
+
+        float terrain = 0.0;
+        for (int i = 0; i < 9; i++) {
+            float fi = float(i);
+            float depth = fi / 8.0;
+            float wave = sin(p.x * (2.2 + depth * 4.8) + time * (0.75 + depth) + bass * 5.0);
+            wave += sin(p.x * (6.0 + depth * 7.0) - time * 0.6 + mids * 4.0) * 0.28;
+            float y = mix(-0.72, 0.44, depth) + wave * (0.035 + audio * 0.08) - depth * depth * 0.18;
+            terrain += terrainLine(p, y, 0.012 + depth * 0.01) * (1.0 - depth * 0.42);
+        }
+
+        float trace = smoothstep(0.018 + audio * 0.018, 0.0, abs(p.y - sin(p.x * 8.0 + time * 2.0) * (0.16 + bass * 0.12)));
+        float transient = smoothstep(0.025, 0.0, abs(p.x - sin(time * 0.9) * 0.68)) * treble;
+        float3 color = low * grid + mid * terrain * (0.75 + audio * 0.8);
+        color += high * trace * (0.42 + audio * 0.38);
+        color += float3(1.0, 0.18, 0.28) * transient * 0.46;
+        color += float3(0.01, 0.012, 0.018) + high * pow(1.0 - abs(uv.y - 0.5), 3.0) * 0.08;
+        return color;
+    }
+
+    static float3 tunnelStage(float2 p,
+                              float2 uv,
+                              float time,
+                              float audio,
+                              float density,
+                              float3 low,
+                              float3 mid,
+                              float3 high,
+                              float bass,
+                              float mids,
+                              float treble) {
+        float radius = length(p);
+        float angle = atan2(p.y, p.x);
+        float speed = 0.85 + audio * 2.0 + treble;
+        float tunnel = sin(log(radius + 0.08) * 18.0 - time * speed + angle * 7.0);
+        float spokes = sin(angle * (10.0 + mids * 12.0) + time);
+        float ring = smoothstep(0.13, 0.0, abs(tunnel + spokes * 0.18));
+        float glow = exp(-radius * (1.6 - bass * 0.55));
+
+        float colorMix = 0.5 + 0.5 * sin(angle + time * 0.22 + bass * 2.4);
+        float3 color = mix(low, mid, colorMix);
+        color = mix(color, high, mids * 0.35);
+        color *= 0.08 + ring * (0.75 + audio * 0.8) + glow * 0.34;
+
+        float orbMask = 0.0;
+        for (int i = 0; i < 12; i++) {
+            orbMask += noteOrb(p, i, time, audio, density);
+        }
+        color = mix(color, high * (1.1 + audio), clamp(orbMask, 0.0, 1.0));
+        return color;
+    }
+
+    static float3 constellationStage(float2 p,
+                                     float2 uv,
+                                     float time,
+                                     float audio,
+                                     float density,
+                                     float3 low,
+                                     float3 mid,
+                                     float3 high,
+                                     float bass,
+                                     float mids,
+                                     float treble) {
+        float3 color = float3(0.006, 0.008, 0.014);
+        float nodeMask = 0.0;
+        float lineMask = 0.0;
+        float count = 16.0;
+
+        for (int i = 0; i < 16; i++) {
+            float fi = float(i);
+            float t = fi / count;
+            float angle = t * 18.84955 + time * (0.08 + bass * 0.18);
+            float radius = 0.18 + fract(sin(fi * 91.7) * 437.2) * 0.78;
+            float2 center = float2(cos(angle) * radius, sin(angle * 0.74 + mids) * radius * 0.72);
+            float d = length(p - center);
+            nodeMask += smoothstep(0.028 + density * 0.008 + audio * 0.03, 0.0, d);
+            lineMask += smoothstep(0.012, 0.0, abs(length(p - center * 0.52) - radius * 0.45)) * 0.08;
+        }
+
+        float star = step(0.988, hash21(floor(uv * 180.0))) * (0.45 + treble);
+        color += low * lineMask;
+        color += high * clamp(nodeMask, 0.0, 1.0) * (0.75 + audio);
+        color += mid * star * 0.35;
+        color += float3(1.0, 0.2, 0.34) * pow(clamp(nodeMask, 0.0, 1.0), 2.0) * treble * 0.45;
+        return color;
+    }
+
+    static float3 liquidStage(float2 p,
+                              float2 uv,
+                              float time,
+                              float audio,
+                              float density,
+                              float3 low,
+                              float3 mid,
+                              float3 high,
+                              float bass,
+                              float mids,
+                              float treble) {
+        float2 q = p;
+        q.x += sin(p.y * 4.0 + time * 0.7) * (0.12 + bass * 0.18);
+        q.y += cos(p.x * 3.0 - time * 0.55) * (0.08 + mids * 0.12);
+        float field = sin(q.x * 5.0 + time) + sin(q.y * 7.0 - time * 1.2);
+        field += sin((q.x + q.y) * 9.0 + treble * 5.0) * 0.35;
+        float contour = smoothstep(0.08 + audio * 0.06, 0.0, abs(field));
+        float caustic = smoothstep(0.035, 0.0, abs(fract(field * 2.0 + time * 0.1) - 0.5)) * 0.22;
+        float3 color = mix(low * 0.12, mid * 0.72, contour);
+        color += high * caustic * (0.6 + density * 0.25);
+        color += float3(1.0, 0.22, 0.34) * treble * smoothstep(0.52, 0.86, uv.x) * 0.18;
+        return color;
+    }
+
+    static float3 spectrogramStage(float2 p,
+                                   float2 uv,
+                                   float time,
+                                   float audio,
+                                   float density,
+                                   float3 low,
+                                   float3 mid,
+                                   float3 high,
+                                   float bass,
+                                   float mids,
+                                   float treble) {
+        float bands = 38.0;
+        float band = floor(uv.x * bands);
+        float lane = fract(uv.x * bands);
+        float profile = sin(band * 0.41 + time * 1.3) * 0.28 + sin(band * 0.13 - time * 0.7) * 0.18;
+        float bandEnergy = clamp(audio * 0.38 + bass * (1.0 - uv.x) + mids * (1.0 - abs(uv.x - 0.5)) + treble * uv.x + profile, 0.04, 1.0);
+        float bar = smoothstep(bandEnergy, bandEnergy - 0.045, uv.y);
+        float separator = smoothstep(0.04, 0.0, abs(lane - 0.5)) * 0.12;
+        float scan = smoothstep(0.012, 0.0, abs(fract(uv.y * 16.0 - time * 0.45) - 0.5)) * 0.18;
+        float3 gradient = mix(low, high, uv.x);
+        gradient = mix(gradient, mid, 1.0 - abs(uv.x - 0.5));
+        return gradient * bar * (0.55 + audio * 0.8) + gradient * separator + high * scan * density;
+    }
+
     fragment half4 oscilloFragment(VertexOut in [[stage_in]],
                                    constant ShaderUniforms &uniforms [[buffer(0)]]) {
         float2 uv = in.uv;
         float aspect = uniforms.resolution.x / max(uniforms.resolution.y, 1.0);
         float2 p = (uv * 2.0 - 1.0) * float2(aspect, 1.0);
-        float radius = length(p);
-        float angle = atan2(p.y, p.x);
 
         float audio = clamp(uniforms.audioLevel * uniforms.visualGain, 0.0, 1.0);
         float density = clamp(uniforms.particleDensity, 0.15, 1.5);
-        float speed = 0.85 + audio * 2.0 + uniforms.trebleEnergy;
-        float tunnel = sin(log(radius + 0.08) * 18.0 - uniforms.time * speed + angle * 7.0);
-        float spokes = sin(angle * (10.0 + uniforms.midEnergy * 12.0) + uniforms.time);
-        float ring = smoothstep(0.13, 0.0, abs(tunnel + spokes * 0.18));
-        float glow = exp(-radius * (1.6 - uniforms.bassEnergy * 0.55));
+
+        float3 audioVector = float3(uniforms.bassEnergy, uniforms.midEnergy, uniforms.trebleEnergy);
+        float3 low = paletteColor(uniforms.paletteIndex, 0, audioVector);
+        float3 mid = paletteColor(uniforms.paletteIndex, 1, audioVector);
+        float3 high = paletteColor(uniforms.paletteIndex, 2, audioVector);
+
+        float3 color;
+        if (uniforms.sceneModeIndex == 1) {
+            color = tunnelStage(p, uv, uniforms.time, audio, density, low, mid, high, uniforms.bassEnergy, uniforms.midEnergy, uniforms.trebleEnergy);
+        } else if (uniforms.sceneModeIndex == 2) {
+            color = constellationStage(p, uv, uniforms.time, audio, density, low, mid, high, uniforms.bassEnergy, uniforms.midEnergy, uniforms.trebleEnergy);
+        } else if (uniforms.sceneModeIndex == 3) {
+            color = liquidStage(p, uv, uniforms.time, audio, density, low, mid, high, uniforms.bassEnergy, uniforms.midEnergy, uniforms.trebleEnergy);
+        } else if (uniforms.sceneModeIndex == 4) {
+            color = spectrogramStage(p, uv, uniforms.time, audio, density, low, mid, high, uniforms.bassEnergy, uniforms.midEnergy, uniforms.trebleEnergy);
+        } else {
+            color = terrainStage(p, uv, uniforms.time, audio, density, low, mid, high, uniforms.bassEnergy, uniforms.midEnergy, uniforms.trebleEnergy);
+        }
 
         float2 starCell = floor(uv * uniforms.resolution / 3.0);
         float starSeed = hash21(starCell);
-        float star = step(0.996, starSeed) * (0.35 + 0.65 * sin(uniforms.time * 2.0 + starSeed * 6.28318));
-
-        float3 audioVector = float3(uniforms.bassEnergy, uniforms.midEnergy, uniforms.trebleEnergy);
-        float3 blue = paletteColor(uniforms.paletteIndex, 0, audioVector);
-        float3 pink = paletteColor(uniforms.paletteIndex, 1, audioVector);
-        float3 green = paletteColor(uniforms.paletteIndex, 2, audioVector);
-        float colorMix = 0.5 + 0.5 * sin(angle + uniforms.time * 0.22 + uniforms.bassEnergy * 2.4);
-
-        float3 color = mix(blue, pink, colorMix);
-        color = mix(color, green, uniforms.midEnergy * 0.35);
-        color *= 0.08 + ring * (0.75 + audio * 0.8) + glow * 0.34;
-        color += star * float3(0.42, 0.7, 1.0);
-        color += pow(max(0.0, 1.0 - radius), 3.0) * uniforms.bassEnergy * float3(0.5, 0.05, 0.18);
-
-        float orbMask = 0.0;
-        for (int i = 0; i < 12; i++) {
-            orbMask += noteOrb(p, i, uniforms.time, audio, density);
-        }
-        orbMask = clamp(orbMask, 0.0, 1.0);
-        color = mix(color, green * (1.1 + audio), orbMask);
-
-        float morphA = smoothstep(0.035 + audio * 0.04, 0.0, abs(length(p - float2(0.46, 0.18)) - 0.11 - sin(uniforms.time) * 0.03));
-        float morphB = smoothstep(0.03 + audio * 0.03, 0.0, abs(length(p - float2(-0.52, -0.22)) - 0.09 - cos(uniforms.time * 0.8) * 0.025));
-        color += (morphA * blue + morphB * pink) * (0.34 + audio * 0.4);
+        float star = step(0.997, starSeed) * (0.24 + 0.52 * sin(uniforms.time * 2.0 + starSeed * 6.28318));
+        color += star * high * 0.42;
+        color = pow(max(color, float3(0.0)), float3(0.92));
 
         return half4(half3(color), 1.0);
     }

--- a/native/Sources/OscilloMac/MetalShaderSource.swift
+++ b/native/Sources/OscilloMac/MetalShaderSource.swift
@@ -22,6 +22,14 @@ enum MetalShaderSource {
         float2 resolution;
     };
 
+    enum SceneModeIndex {
+        sceneModeSpectralTerrain = 0,
+        sceneModeTunnel = 1,
+        sceneModeConstellation = 2,
+        sceneModeLiquidSurface = 3,
+        sceneModeSpectrogramStage = 4
+    };
+
     vertex VertexOut oscilloVertex(uint vertexID [[vertex_id]]) {
         float2 positions[3] = {
             float2(-1.0, -1.0),
@@ -98,10 +106,11 @@ enum MetalShaderSource {
                                float bass,
                                float mids,
                                float treble) {
+        float densityResponse = clamp(density, 0.15, 1.5);
         float grid = 0.0;
         float2 gp = abs(fract((p + float2(0.0, time * 0.035)) * float2(7.0, 5.0)) - 0.5);
-        grid += smoothstep(0.018, 0.0, gp.x) * 0.16;
-        grid += smoothstep(0.014, 0.0, gp.y) * 0.12;
+        grid += smoothstep(0.018, 0.0, gp.x) * (0.12 + densityResponse * 0.035);
+        grid += smoothstep(0.014, 0.0, gp.y) * (0.09 + densityResponse * 0.025);
 
         float terrain = 0.0;
         for (int i = 0; i < 9; i++) {
@@ -109,8 +118,8 @@ enum MetalShaderSource {
             float depth = fi / 8.0;
             float wave = sin(p.x * (2.2 + depth * 4.8) + time * (0.75 + depth) + bass * 5.0);
             wave += sin(p.x * (6.0 + depth * 7.0) - time * 0.6 + mids * 4.0) * 0.28;
-            float y = mix(-0.72, 0.44, depth) + wave * (0.035 + audio * 0.08) - depth * depth * 0.18;
-            terrain += terrainLine(p, y, 0.012 + depth * 0.01) * (1.0 - depth * 0.42);
+            float y = mix(-0.72, 0.44, depth) + wave * (0.035 + audio * 0.08 + densityResponse * 0.01) - depth * depth * 0.18;
+            terrain += terrainLine(p, y, 0.012 + depth * 0.01 + densityResponse * 0.002) * (1.0 - depth * 0.42);
         }
 
         float trace = smoothstep(0.018 + audio * 0.018, 0.0, abs(p.y - sin(p.x * 8.0 + time * 2.0) * (0.16 + bass * 0.12)));
@@ -229,8 +238,8 @@ enum MetalShaderSource {
         float lane = fract(uv.x * bands);
         float profile = sin(band * 0.41 + time * 1.3) * 0.28 + sin(band * 0.13 - time * 0.7) * 0.18;
         float bandEnergy = clamp(audio * 0.38 + bass * (1.0 - uv.x) + mids * (1.0 - abs(uv.x - 0.5)) + treble * uv.x + profile, 0.04, 1.0);
-        float bar = smoothstep(bandEnergy, bandEnergy - 0.045, uv.y);
-        float separator = smoothstep(0.04, 0.0, abs(lane - 0.5)) * 0.12;
+        float bar = 1.0 - smoothstep(bandEnergy - 0.045, bandEnergy, uv.y);
+        float separator = (1.0 - smoothstep(0.0, 0.04, abs(lane - 0.5))) * 0.12;
         float scan = smoothstep(0.012, 0.0, abs(fract(uv.y * 16.0 - time * 0.45) - 0.5)) * 0.18;
         float3 gradient = mix(low, high, uv.x);
         gradient = mix(gradient, mid, 1.0 - abs(uv.x - 0.5));
@@ -252,16 +261,23 @@ enum MetalShaderSource {
         float3 high = paletteColor(uniforms.paletteIndex, 2, audioVector);
 
         float3 color;
-        if (uniforms.sceneModeIndex == 1) {
+        switch (uniforms.sceneModeIndex) {
+        case sceneModeTunnel:
             color = tunnelStage(p, uv, uniforms.time, audio, density, low, mid, high, uniforms.bassEnergy, uniforms.midEnergy, uniforms.trebleEnergy);
-        } else if (uniforms.sceneModeIndex == 2) {
+            break;
+        case sceneModeConstellation:
             color = constellationStage(p, uv, uniforms.time, audio, density, low, mid, high, uniforms.bassEnergy, uniforms.midEnergy, uniforms.trebleEnergy);
-        } else if (uniforms.sceneModeIndex == 3) {
+            break;
+        case sceneModeLiquidSurface:
             color = liquidStage(p, uv, uniforms.time, audio, density, low, mid, high, uniforms.bassEnergy, uniforms.midEnergy, uniforms.trebleEnergy);
-        } else if (uniforms.sceneModeIndex == 4) {
+            break;
+        case sceneModeSpectrogramStage:
             color = spectrogramStage(p, uv, uniforms.time, audio, density, low, mid, high, uniforms.bassEnergy, uniforms.midEnergy, uniforms.trebleEnergy);
-        } else {
+            break;
+        case sceneModeSpectralTerrain:
+        default:
             color = terrainStage(p, uv, uniforms.time, audio, density, low, mid, high, uniforms.bassEnergy, uniforms.midEnergy, uniforms.trebleEnergy);
+            break;
         }
 
         float2 starCell = floor(uv * uniforms.resolution / 3.0);

--- a/native/Sources/OscilloMac/OscilloRenderer.swift
+++ b/native/Sources/OscilloMac/OscilloRenderer.swift
@@ -83,6 +83,7 @@ final class OscilloRenderer: NSObject, MTKViewDelegate {
             visualGain: settings.visualGain,
             particleDensity: settings.particleDensity,
             paletteIndex: settings.palette.uniformIndex,
+            sceneModeIndex: settings.sceneMode.uniformIndex,
             padding: 0,
             resolution: SIMD2<Float>(Float(max(size.width, 1)), Float(max(size.height, 1)))
         )
@@ -98,6 +99,7 @@ private struct ShaderUniforms {
     var visualGain: Float
     var particleDensity: Float
     var paletteIndex: Int32
+    var sceneModeIndex: Int32
     var padding: Float
     var resolution: SIMD2<Float>
 }

--- a/native/Sources/OscilloMac/SceneController.swift
+++ b/native/Sources/OscilloMac/SceneController.swift
@@ -17,7 +17,8 @@ final class SceneController: ObservableObject {
             visualGain: value,
             particleDensity: settings.particleDensity,
             previewTempo: settings.previewTempo,
-            palette: settings.palette
+            palette: settings.palette,
+            sceneMode: settings.sceneMode
         )
     }
 
@@ -26,7 +27,8 @@ final class SceneController: ObservableObject {
             visualGain: settings.visualGain,
             particleDensity: value,
             previewTempo: settings.previewTempo,
-            palette: settings.palette
+            palette: settings.palette,
+            sceneMode: settings.sceneMode
         )
     }
 
@@ -35,7 +37,8 @@ final class SceneController: ObservableObject {
             visualGain: settings.visualGain,
             particleDensity: settings.particleDensity,
             previewTempo: value,
-            palette: settings.palette
+            palette: settings.palette,
+            sceneMode: settings.sceneMode
         )
     }
 
@@ -44,7 +47,18 @@ final class SceneController: ObservableObject {
             visualGain: settings.visualGain,
             particleDensity: settings.particleDensity,
             previewTempo: settings.previewTempo,
-            palette: palette
+            palette: palette,
+            sceneMode: settings.sceneMode
+        )
+    }
+
+    func setSceneMode(_ sceneMode: SceneMode) {
+        update(
+            visualGain: settings.visualGain,
+            particleDensity: settings.particleDensity,
+            previewTempo: settings.previewTempo,
+            palette: settings.palette,
+            sceneMode: sceneMode
         )
     }
 
@@ -52,13 +66,15 @@ final class SceneController: ObservableObject {
         visualGain: Float,
         particleDensity: Float,
         previewTempo: Float,
-        palette: ScenePalette
+        palette: ScenePalette,
+        sceneMode: SceneMode
     ) {
         let next = SceneSettings(
             visualGain: visualGain,
             particleDensity: particleDensity,
             previewTempo: previewTempo,
-            palette: palette
+            palette: palette,
+            sceneMode: sceneMode
         )
         settings = next
         settingsStore.update(next)

--- a/native/Tests/OscilloCoreTests/AppBundleMetadataTests.swift
+++ b/native/Tests/OscilloCoreTests/AppBundleMetadataTests.swift
@@ -15,8 +15,8 @@ final class AppBundleMetadataTests: XCTestCase {
         XCTAssertEqual(plist["CFBundleExecutable"] as? String, "OscilloMac")
         XCTAssertEqual(plist["CFBundlePackageType"] as? String, "APPL")
         XCTAssertEqual(plist["CFBundleIdentifier"] as? String, "com.zachyzissou.oscillo.native.mac")
-        XCTAssertEqual(plist["CFBundleShortVersionString"] as? String, "0.1.5")
-        XCTAssertEqual(plist["CFBundleVersion"] as? String, "6")
+        XCTAssertEqual(plist["CFBundleShortVersionString"] as? String, "0.1.6")
+        XCTAssertEqual(plist["CFBundleVersion"] as? String, "7")
         XCTAssertEqual(
             plist["NSMicrophoneUsageDescription"] as? String,
             "Oscillo uses microphone input to drive real-time audio-reactive visuals."

--- a/native/Tests/OscilloCoreTests/SceneSettingsTests.swift
+++ b/native/Tests/OscilloCoreTests/SceneSettingsTests.swift
@@ -7,13 +7,15 @@ final class SceneSettingsTests: XCTestCase {
             visualGain: 4.5,
             particleDensity: -2,
             previewTempo: 4,
-            palette: .solar
+            palette: .solar,
+            sceneMode: .liquidSurface
         )
 
         XCTAssertEqual(settings.visualGain, 2.0)
         XCTAssertEqual(settings.particleDensity, 0.15)
         XCTAssertEqual(settings.previewTempo, 2.0)
         XCTAssertEqual(settings.palette, .solar)
+        XCTAssertEqual(settings.sceneMode, .liquidSurface)
     }
 
     func testStorePublishesThreadSafeSnapshots() {
@@ -22,7 +24,8 @@ final class SceneSettingsTests: XCTestCase {
             visualGain: 0.5,
             particleDensity: 0.8,
             previewTempo: 1.25,
-            palette: .aurora
+            palette: .aurora,
+            sceneMode: .constellation
         ))
 
         let snapshot = store.snapshot()
@@ -31,6 +34,7 @@ final class SceneSettingsTests: XCTestCase {
         XCTAssertEqual(snapshot.particleDensity, 0.8)
         XCTAssertEqual(snapshot.previewTempo, 1.25)
         XCTAssertEqual(snapshot.palette, .aurora)
+        XCTAssertEqual(snapshot.sceneMode, .constellation)
     }
 
     func testPaletteIndexIsStableForMetalUniforms() {
@@ -38,5 +42,13 @@ final class SceneSettingsTests: XCTestCase {
         XCTAssertEqual(ScenePalette.aurora.uniformIndex, 1)
         XCTAssertEqual(ScenePalette.solar.uniformIndex, 2)
         XCTAssertEqual(ScenePalette.mono.uniformIndex, 3)
+    }
+
+    func testSceneModeIndexIsStableForMetalUniforms() {
+        XCTAssertEqual(SceneMode.spectralTerrain.uniformIndex, 0)
+        XCTAssertEqual(SceneMode.tunnel.uniformIndex, 1)
+        XCTAssertEqual(SceneMode.constellation.uniformIndex, 2)
+        XCTAssertEqual(SceneMode.liquidSurface.uniformIndex, 3)
+        XCTAssertEqual(SceneMode.spectrogramStage.uniformIndex, 4)
     }
 }


### PR DESCRIPTION
## Summary
- rework the native macOS UI into a Signal Foundry instrument surface with a left instrument spine, top status deck, and bottom signal console
- add scene modes to shared settings and Metal uniforms, with distinct shader stages for spectral terrain, tunnel, constellation, liquid surface, and spectrogram stage
- bump native app to 0.1.6/build 7 and document Stitch generated concepts plus the corrected variantOptions API shape

Closes #432

## Verification
- `git diff --check`
- `DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer swift test`
- `DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer CONFIGURATION=release ./Scripts/build-macos-app.sh`
- `codesign --verify --deep --strict --verbose=1 native/dist/Oscillo.app`
- runtime smoke: `DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer swift run OscilloMac` for 5 seconds, no shader compile/assertion output