### PR TITLE
ci(security): guard against committed secrets

### DIFF
--- a/.github/workflows/secret-guard.yml
+++ b/.github/workflows/secret-guard.yml
@@ -1,0 +1,19 @@
+name: Secret Guard
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  tracked-secret-guard:
+    name: Tracked secret guard
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6.0.2
+      - name: Check tracked files for secrets
+        run: native/Scripts/check-no-secrets.sh

--- a/.github/workflows/secret-guard.yml
+++ b/.github/workflows/secret-guard.yml
@@ -16,4 +16,4 @@ jobs:
     steps:
       - uses: actions/checkout@v6.0.2
       - name: Check tracked files for secrets
-        run: native/Scripts/check-no-secrets.sh
+        run: bash native/Scripts/check-no-secrets.sh

--- a/native/Scripts/check-no-secrets.sh
+++ b/native/Scripts/check-no-secrets.sh
@@ -4,7 +4,8 @@ set -euo pipefail
 ROOT="$(git rev-parse --show-toplevel)"
 cd "$ROOT"
 
-failures="$(mktemp)"
+tmp_dir="${TMPDIR:-/tmp}"
+failures="$(mktemp "${tmp_dir%/}/oscillo-secret-guard.XXXXXX")"
 trap 'rm -f "$failures"' EXIT
 
 while IFS= read -r file; do

--- a/native/Scripts/check-no-secrets.sh
+++ b/native/Scripts/check-no-secrets.sh
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(git rev-parse --show-toplevel)"
+cd "$ROOT"
+
+failures="$(mktemp)"
+trap 'rm -f "$failures"' EXIT
+
+while IFS= read -r file; do
+  case "$file" in
+    native/secrets/*)
+      printf 'forbidden tracked signing material: %s\n' "$file" >> "$failures"
+      ;;
+    .env|.env.*|*/.env|*/.env.*)
+      case "$file" in
+        .env.example|*.example)
+          ;;
+        *)
+          printf 'forbidden tracked environment file: %s\n' "$file" >> "$failures"
+          ;;
+      esac
+      ;;
+    *.p12|*.pfx|*.mobileprovision|*.provisionprofile|*.certSigningRequest|*.csr|*.key|*.pem)
+      printf 'forbidden tracked credential-like file: %s\n' "$file" >> "$failures"
+      ;;
+  esac
+done < <(git ls-files)
+
+git grep -nI -E \
+  -e '-----BEGIN (RSA |DSA |EC |OPENSSH |PGP )?PRIVATE KEY( BLOCK)?-----' \
+  -e 'AKIA[0-9A-Z]{16}' \
+  -e 'github_pat_[A-Za-z0-9_]{20,}' \
+  -e 'gh[pousr]_[A-Za-z0-9_]{30,}' \
+  -e 'xox[baprs]-[A-Za-z0-9-]{20,}' \
+  -- . ':!package-lock.json' ':!native/Package.resolved' \
+  >> "$failures" || true
+
+if [[ -s "$failures" ]]; then
+  echo "Tracked secret guard failed. Remove these files or rotate the exposed credential before pushing:" >&2
+  cat "$failures" >&2
+  exit 1
+fi
+
+echo "Tracked secret guard passed."

--- a/native/UPDATES.md
+++ b/native/UPDATES.md
@@ -68,3 +68,11 @@ native/Scripts/configure-macos-signing-secrets.sh /path/to/developer_id_applicat
 ```
 
 The script builds a password-protected `.p12` from the local private key, pushes the GitHub secrets, and leaves the generated key material under ignored `native/secrets/`.
+
+Before pushing release changes, run the tracked-file secret guard:
+
+```bash
+native/Scripts/check-no-secrets.sh
+```
+
+The guard scans files already tracked by Git and fails if signing material, real `.env` files, private-key blocks, or common credential token formats are present in the repository.

--- a/native/UPDATES.md
+++ b/native/UPDATES.md
@@ -72,7 +72,7 @@ The script builds a password-protected `.p12` from the local private key, pushes
 Before pushing release changes, run the tracked-file secret guard:
 
 ```bash
-native/Scripts/check-no-secrets.sh
+bash native/Scripts/check-no-secrets.sh
 ```
 
 The guard scans files already tracked by Git and fails if signing material, real `.env` files, private-key blocks, or common credential token formats are present in the repository.

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "build:analyze": "ANALYZE=true npm run build",
     "security:audit": "npm audit --audit-level moderate",
     "security:fix": "npm audit fix",
+    "security:secrets": "bash native/Scripts/check-no-secrets.sh",
     "release:prepare": "changeset version && npm install --package-lock-only && npm run build",
     "prepare": "husky install",
     "jam-server": "node server/jam-server.js",

--- a/package.json
+++ b/package.json
@@ -31,7 +31,6 @@
     "build:analyze": "ANALYZE=true npm run build",
     "security:audit": "npm audit --audit-level moderate",
     "security:fix": "npm audit fix",
-    "security:secrets": "bash native/Scripts/check-no-secrets.sh",
     "release:prepare": "changeset version && npm install --package-lock-only && npm run build",
     "prepare": "husky install",
     "jam-server": "node server/jam-server.js",


### PR DESCRIPTION
## Summary\n- add a tracked-file secret guard for native signing material, real .env files, private-key markers, and common credential token patterns\n- run the guard in a dedicated GitHub Actions workflow on every PR/push\n- document the native release command without touching the legacy web package/smoke lane\n\nCloses #438\n\n## Verification\n- bash native/Scripts/check-no-secrets.sh\n- bash -n native/Scripts/check-no-secrets.sh\n- node -e "JSON.parse(require('fs').readFileSync('package.json','utf8')); console.log('package.json ok')"\n- git diff --check\n- temporary-index negative test: native/secrets/secret-guard-fake.key fails\n- temporary-index negative test: private-key marker fails