### PR TITLE
feat(native): add performance presets

### DIFF
--- a/native/AppBundle/Info.plist
+++ b/native/AppBundle/Info.plist
@@ -17,9 +17,9 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>0.1.8</string>
+	<string>0.1.9</string>
 	<key>CFBundleVersion</key>
-	<string>9</string>
+	<string>10</string>
 	<key>LSApplicationCategoryType</key>
 	<string>public.app-category.music</string>
 	<key>LSMinimumSystemVersion</key>

--- a/native/Sources/OscilloCore/SceneSettings.swift
+++ b/native/Sources/OscilloCore/SceneSettings.swift
@@ -90,6 +90,78 @@ public enum SceneMode: String, CaseIterable, Equatable, Identifiable, Sendable {
     }
 }
 
+public enum PerformancePreset: String, CaseIterable, Equatable, Identifiable, Sendable {
+    case drift
+    case pulse
+    case orbit
+    case surge
+
+    public var id: String { rawValue }
+
+    public var displayName: String {
+        switch self {
+        case .drift:
+            "Drift"
+        case .pulse:
+            "Pulse"
+        case .orbit:
+            "Orbit"
+        case .surge:
+            "Surge"
+        }
+    }
+
+    public var shortName: String {
+        switch self {
+        case .drift:
+            "Drift"
+        case .pulse:
+            "Pulse"
+        case .orbit:
+            "Orbit"
+        case .surge:
+            "Surge"
+        }
+    }
+
+    public var settings: SceneSettings {
+        switch self {
+        case .drift:
+            SceneSettings(
+                visualGain: 0.82,
+                particleDensity: 0.62,
+                previewTempo: 0.72,
+                palette: .aurora,
+                sceneMode: .spectralTerrain
+            )
+        case .pulse:
+            SceneSettings(
+                visualGain: 1.32,
+                particleDensity: 0.96,
+                previewTempo: 1.18,
+                palette: .neon,
+                sceneMode: .tunnel
+            )
+        case .orbit:
+            SceneSettings(
+                visualGain: 1.08,
+                particleDensity: 1.22,
+                previewTempo: 0.94,
+                palette: .mono,
+                sceneMode: .constellation
+            )
+        case .surge:
+            SceneSettings(
+                visualGain: 1.64,
+                particleDensity: 1.36,
+                previewTempo: 1.46,
+                palette: .solar,
+                sceneMode: .spectrogramStage
+            )
+        }
+    }
+}
+
 public struct SceneSettings: Equatable, Sendable {
     public var visualGain: Float
     public var particleDensity: Float

--- a/native/Sources/OscilloCore/SceneSettings.swift
+++ b/native/Sources/OscilloCore/SceneSettings.swift
@@ -111,18 +111,7 @@ public enum PerformancePreset: String, CaseIterable, Equatable, Identifiable, Se
         }
     }
 
-    public var shortName: String {
-        switch self {
-        case .drift:
-            "Drift"
-        case .pulse:
-            "Pulse"
-        case .orbit:
-            "Orbit"
-        case .surge:
-            "Surge"
-        }
-    }
+    public var shortName: String { displayName }
 
     public var settings: SceneSettings {
         switch self {

--- a/native/Sources/OscilloMac/ContentView.swift
+++ b/native/Sources/OscilloMac/ContentView.swift
@@ -153,7 +153,7 @@ private struct InstrumentSpine: View {
                         ForEach(PerformancePreset.allCases) { preset in
                             PerformancePresetPill(
                                 preset: preset,
-                                isSelected: sceneController.settings == preset.settings
+                                isSelected: sceneController.selectedPreset == preset
                             ) {
                                 sceneController.applyPreset(preset)
                             }

--- a/native/Sources/OscilloMac/ContentView.swift
+++ b/native/Sources/OscilloMac/ContentView.swift
@@ -145,6 +145,23 @@ private struct InstrumentSpine: View {
                 SignalReadoutModule(audioEngine: audioEngine)
 
                 VStack(alignment: .leading, spacing: 8) {
+                    ModuleLabel("PERFORM")
+                    LazyVGrid(columns: [
+                        GridItem(.flexible(), spacing: 6),
+                        GridItem(.flexible(), spacing: 6)
+                    ], spacing: 6) {
+                        ForEach(PerformancePreset.allCases) { preset in
+                            PerformancePresetPill(
+                                preset: preset,
+                                isSelected: sceneController.settings == preset.settings
+                            ) {
+                                sceneController.applyPreset(preset)
+                            }
+                        }
+                    }
+                }
+
+                VStack(alignment: .leading, spacing: 8) {
                     ModuleLabel("SCENE")
                     LazyVGrid(columns: [
                         GridItem(.flexible(), spacing: 6),
@@ -366,6 +383,58 @@ private struct SceneModePill: View {
             RoundedRectangle(cornerRadius: 5)
                 .stroke(isSelected ? SignalTheme.signalTeal : SignalTheme.gridLine, lineWidth: 1)
         )
+    }
+}
+
+private struct PerformancePresetPill: View {
+    let preset: PerformancePreset
+    let isSelected: Bool
+    let action: () -> Void
+
+    var body: some View {
+        Button(action: action) {
+            HStack(spacing: 6) {
+                Image(systemName: systemImage)
+                    .font(.system(size: 10, weight: .black))
+                Text(preset.shortName.uppercased())
+                    .font(.system(size: 10, weight: .bold, design: .monospaced))
+            }
+            .frame(maxWidth: .infinity)
+            .padding(.vertical, 7)
+        }
+        .buttonStyle(.plain)
+        .foregroundStyle(isSelected ? SignalTheme.voidBlack : accent)
+        .background(isSelected ? accent : SignalTheme.raisedGraphite, in: RoundedRectangle(cornerRadius: 5))
+        .overlay(
+            RoundedRectangle(cornerRadius: 5)
+                .stroke(isSelected ? accent : SignalTheme.gridLine, lineWidth: 1)
+        )
+    }
+
+    private var accent: Color {
+        switch preset {
+        case .drift:
+            SignalTheme.signalTeal
+        case .pulse:
+            SignalTheme.transientCoral
+        case .orbit:
+            SignalTheme.oscillatorCyan
+        case .surge:
+            SignalTheme.warmPeak
+        }
+    }
+
+    private var systemImage: String {
+        switch preset {
+        case .drift:
+            "wind"
+        case .pulse:
+            "bolt.fill"
+        case .orbit:
+            "sparkle"
+        case .surge:
+            "waveform.path.ecg"
+        }
     }
 }
 

--- a/native/Sources/OscilloMac/SceneController.swift
+++ b/native/Sources/OscilloMac/SceneController.swift
@@ -62,6 +62,11 @@ final class SceneController: ObservableObject {
         )
     }
 
+    func applyPreset(_ preset: PerformancePreset) {
+        settings = preset.settings
+        settingsStore.update(preset.settings)
+    }
+
     private func update(
         visualGain: Float,
         particleDensity: Float,

--- a/native/Sources/OscilloMac/SceneController.swift
+++ b/native/Sources/OscilloMac/SceneController.swift
@@ -4,6 +4,7 @@ import SwiftUI
 @MainActor
 final class SceneController: ObservableObject {
     @Published private(set) var settings: SceneSettings
+    @Published private(set) var selectedPreset: PerformancePreset?
 
     let settingsStore: SceneSettingsStore
 
@@ -63,8 +64,10 @@ final class SceneController: ObservableObject {
     }
 
     func applyPreset(_ preset: PerformancePreset) {
-        settings = preset.settings
-        settingsStore.update(preset.settings)
+        let next = preset.settings
+        settings = next
+        selectedPreset = preset
+        settingsStore.update(next)
     }
 
     private func update(
@@ -82,6 +85,7 @@ final class SceneController: ObservableObject {
             sceneMode: sceneMode
         )
         settings = next
+        selectedPreset = nil
         settingsStore.update(next)
     }
 }

--- a/native/Tests/OscilloCoreTests/AppBundleMetadataTests.swift
+++ b/native/Tests/OscilloCoreTests/AppBundleMetadataTests.swift
@@ -15,8 +15,8 @@ final class AppBundleMetadataTests: XCTestCase {
         XCTAssertEqual(plist["CFBundleExecutable"] as? String, "OscilloMac")
         XCTAssertEqual(plist["CFBundlePackageType"] as? String, "APPL")
         XCTAssertEqual(plist["CFBundleIdentifier"] as? String, "com.zachyzissou.oscillo.native.mac")
-        XCTAssertEqual(plist["CFBundleShortVersionString"] as? String, "0.1.8")
-        XCTAssertEqual(plist["CFBundleVersion"] as? String, "9")
+        XCTAssertEqual(plist["CFBundleShortVersionString"] as? String, "0.1.9")
+        XCTAssertEqual(plist["CFBundleVersion"] as? String, "10")
         XCTAssertEqual(
             plist["NSMicrophoneUsageDescription"] as? String,
             "Oscillo uses microphone input to drive real-time audio-reactive visuals."

--- a/native/Tests/OscilloCoreTests/SceneSettingsTests.swift
+++ b/native/Tests/OscilloCoreTests/SceneSettingsTests.swift
@@ -51,4 +51,33 @@ final class SceneSettingsTests: XCTestCase {
         XCTAssertEqual(SceneMode.liquidSurface.uniformIndex, 3)
         XCTAssertEqual(SceneMode.spectrogramStage.uniformIndex, 4)
     }
+
+    func testPerformancePresetsAreValidControlSnapshots() {
+        XCTAssertEqual(PerformancePreset.allCases.count, 4)
+
+        for preset in PerformancePreset.allCases {
+            let settings = preset.settings
+            XCTAssertEqual(settings.visualGain, settings.visualGain.clamped(to: 0.25...2.0))
+            XCTAssertEqual(settings.particleDensity, settings.particleDensity.clamped(to: 0.15...1.5))
+            XCTAssertEqual(settings.previewTempo, settings.previewTempo.clamped(to: 0.5...2.0))
+        }
+    }
+
+    func testPerformancePresetsCoverDistinctScenesAndPalettes() {
+        XCTAssertEqual(PerformancePreset.drift.settings.sceneMode, .spectralTerrain)
+        XCTAssertEqual(PerformancePreset.pulse.settings.sceneMode, .tunnel)
+        XCTAssertEqual(PerformancePreset.orbit.settings.sceneMode, .constellation)
+        XCTAssertEqual(PerformancePreset.surge.settings.sceneMode, .spectrogramStage)
+
+        XCTAssertEqual(PerformancePreset.drift.settings.palette, .aurora)
+        XCTAssertEqual(PerformancePreset.pulse.settings.palette, .neon)
+        XCTAssertEqual(PerformancePreset.orbit.settings.palette, .mono)
+        XCTAssertEqual(PerformancePreset.surge.settings.palette, .solar)
+    }
+}
+
+private extension Float {
+    func clamped(to range: ClosedRange<Float>) -> Float {
+        min(max(self, range.lowerBound), range.upperBound)
+    }
 }


### PR DESCRIPTION
## Summary\n- add shared PerformancePreset snapshots for Drift, Pulse, Orbit, and Surge\n- expose presets in the macOS instrument rail so one action reshapes scene, palette, gain, particles, and preview tempo\n- bump native app metadata to 0.1.9 build 10\n\nCloses #440\n\n## Verification\n- DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer swift test\n- DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer CONFIGURATION=release ./Scripts/build-macos-app.sh\n- codesign --verify --deep --strict --verbose=1 native/dist/Oscillo.app\n- plutil -p native/dist/Oscillo.app/Contents/Info.plist | rg 'CFBundleShortVersionString|CFBundleVersion'\n- bash native/Scripts/check-no-secrets.sh\n- local screenshot: /tmp/oscillo-0.1.9-presets-local.png