### PR TITLE
feat(native): add keyboard performance controls

### DIFF
--- a/native/AppBundle/Info.plist
+++ b/native/AppBundle/Info.plist
@@ -17,9 +17,9 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>0.1.9</string>
+	<string>0.2.0</string>
 	<key>CFBundleVersion</key>
-	<string>10</string>
+	<string>11</string>
 	<key>LSApplicationCategoryType</key>
 	<string>public.app-category.music</string>
 	<key>LSMinimumSystemVersion</key>

--- a/native/Sources/OscilloCore/PerformanceCommand.swift
+++ b/native/Sources/OscilloCore/PerformanceCommand.swift
@@ -19,7 +19,7 @@ public enum PerformanceCommand: Equatable, Sendable {
         }
     }
 
-    public var keyEquivalent: String {
+    public var keyEquivalent: Character {
         switch self {
         case .togglePreview:
             " "
@@ -34,7 +34,7 @@ public enum PerformanceCommand: Equatable, Sendable {
 }
 
 public extension SceneMode {
-    var performanceKey: String {
+    var performanceKey: Character {
         switch self {
         case .spectralTerrain:
             "1"
@@ -51,7 +51,7 @@ public extension SceneMode {
 }
 
 public extension PerformancePreset {
-    var performanceKey: String {
+    var performanceKey: Character {
         switch self {
         case .drift:
             "q"

--- a/native/Sources/OscilloCore/PerformanceCommand.swift
+++ b/native/Sources/OscilloCore/PerformanceCommand.swift
@@ -1,0 +1,66 @@
+import Foundation
+
+public enum PerformanceCommand: Equatable, Sendable {
+    case togglePreview
+    case toggleMicrophone
+    case scene(SceneMode)
+    case preset(PerformancePreset)
+
+    public var title: String {
+        switch self {
+        case .togglePreview:
+            "Toggle Preview"
+        case .toggleMicrophone:
+            "Toggle Microphone"
+        case .scene(let sceneMode):
+            sceneMode.displayName
+        case .preset(let preset):
+            preset.displayName
+        }
+    }
+
+    public var keyEquivalent: String {
+        switch self {
+        case .togglePreview:
+            " "
+        case .toggleMicrophone:
+            "m"
+        case .scene(let sceneMode):
+            sceneMode.performanceKey
+        case .preset(let preset):
+            preset.performanceKey
+        }
+    }
+}
+
+public extension SceneMode {
+    var performanceKey: String {
+        switch self {
+        case .spectralTerrain:
+            "1"
+        case .tunnel:
+            "2"
+        case .constellation:
+            "3"
+        case .liquidSurface:
+            "4"
+        case .spectrogramStage:
+            "5"
+        }
+    }
+}
+
+public extension PerformancePreset {
+    var performanceKey: String {
+        switch self {
+        case .drift:
+            "q"
+        case .pulse:
+            "w"
+        case .orbit:
+            "e"
+        case .surge:
+            "r"
+        }
+    }
+}

--- a/native/Sources/OscilloMac/ContentView.swift
+++ b/native/Sources/OscilloMac/ContentView.swift
@@ -233,19 +233,11 @@ private struct InstrumentSpine: View {
     }
 
     private func toggleMicrophone() {
-        if audioEngine.isRunning {
-            audioEngine.stopMicrophone()
-        } else {
-            audioEngine.startMicrophone()
-        }
+        audioEngine.toggleMicrophone()
     }
 
     private func togglePreview() {
-        if audioEngine.isPreviewing {
-            audioEngine.stopPreview(resetFeatures: true)
-        } else {
-            audioEngine.startPreview()
-        }
+        audioEngine.togglePreview()
     }
 }
 

--- a/native/Sources/OscilloMac/LiveAudioEngine.swift
+++ b/native/Sources/OscilloMac/LiveAudioEngine.swift
@@ -75,9 +75,9 @@ final class LiveAudioEngine: ObservableObject {
     }
 
     func startPreview() {
-        guard previewTimer == nil else { return }
+        guard !isRunning, previewTimer == nil else { return }
         isPreviewing = true
-        statusMessage = isRunning ? "Microphone input" : "Preview signal"
+        statusMessage = "Preview signal"
         beginPublishing()
 
         previewTimer = Timer.scheduledTimer(withTimeInterval: 1.0 / 60.0, repeats: true) { [weak self] _ in
@@ -104,6 +104,8 @@ final class LiveAudioEngine: ObservableObject {
     func togglePreview() {
         if isPreviewing {
             stopPreview(resetFeatures: true)
+        } else if isRunning {
+            stopMicrophone()
         } else {
             startPreview()
         }

--- a/native/Sources/OscilloMac/LiveAudioEngine.swift
+++ b/native/Sources/OscilloMac/LiveAudioEngine.swift
@@ -66,6 +66,14 @@ final class LiveAudioEngine: ObservableObject {
         startPreview()
     }
 
+    func toggleMicrophone() {
+        if isRunning {
+            stopMicrophone()
+        } else {
+            startMicrophone()
+        }
+    }
+
     func startPreview() {
         guard previewTimer == nil else { return }
         isPreviewing = true
@@ -91,6 +99,14 @@ final class LiveAudioEngine: ObservableObject {
         }
 
         stopPublishingIfIdle()
+    }
+
+    func togglePreview() {
+        if isPreviewing {
+            stopPreview(resetFeatures: true)
+        } else {
+            startPreview()
+        }
     }
 
     private func beginPublishing() {

--- a/native/Sources/OscilloMac/OscilloMacApp.swift
+++ b/native/Sources/OscilloMac/OscilloMacApp.swift
@@ -18,5 +18,42 @@ struct OscilloMacApp: App {
                 .frame(minWidth: 960, minHeight: 640)
         }
         .windowStyle(.hiddenTitleBar)
+        .commands {
+            CommandMenu("Perform") {
+                Button(PerformanceCommand.togglePreview.title) {
+                    audioEngine.togglePreview()
+                }
+                .keyboardShortcut(.space, modifiers: [])
+
+                Button(PerformanceCommand.toggleMicrophone.title) {
+                    audioEngine.toggleMicrophone()
+                }
+                .keyboardShortcut("m", modifiers: [])
+
+                Divider()
+
+                ForEach(PerformancePreset.allCases) { preset in
+                    Button(PerformanceCommand.preset(preset).title) {
+                        sceneController.applyPreset(preset)
+                    }
+                    .keyboardShortcut(
+                        KeyEquivalent(Character(preset.performanceKey)),
+                        modifiers: []
+                    )
+                }
+
+                Divider()
+
+                ForEach(SceneMode.allCases) { sceneMode in
+                    Button(PerformanceCommand.scene(sceneMode).title) {
+                        sceneController.setSceneMode(sceneMode)
+                    }
+                    .keyboardShortcut(
+                        KeyEquivalent(Character(sceneMode.performanceKey)),
+                        modifiers: []
+                    )
+                }
+            }
+        }
     }
 }

--- a/native/Sources/OscilloMac/OscilloMacApp.swift
+++ b/native/Sources/OscilloMac/OscilloMacApp.swift
@@ -23,12 +23,18 @@ struct OscilloMacApp: App {
                 Button(PerformanceCommand.togglePreview.title) {
                     audioEngine.togglePreview()
                 }
-                .keyboardShortcut(.space, modifiers: [])
+                .keyboardShortcut(
+                    KeyEquivalent(PerformanceCommand.togglePreview.keyEquivalent),
+                    modifiers: []
+                )
 
                 Button(PerformanceCommand.toggleMicrophone.title) {
                     audioEngine.toggleMicrophone()
                 }
-                .keyboardShortcut("m", modifiers: [])
+                .keyboardShortcut(
+                    KeyEquivalent(PerformanceCommand.toggleMicrophone.keyEquivalent),
+                    modifiers: []
+                )
 
                 Divider()
 
@@ -37,7 +43,7 @@ struct OscilloMacApp: App {
                         sceneController.applyPreset(preset)
                     }
                     .keyboardShortcut(
-                        KeyEquivalent(Character(preset.performanceKey)),
+                        KeyEquivalent(PerformanceCommand.preset(preset).keyEquivalent),
                         modifiers: []
                     )
                 }
@@ -49,7 +55,7 @@ struct OscilloMacApp: App {
                         sceneController.setSceneMode(sceneMode)
                     }
                     .keyboardShortcut(
-                        KeyEquivalent(Character(sceneMode.performanceKey)),
+                        KeyEquivalent(PerformanceCommand.scene(sceneMode).keyEquivalent),
                         modifiers: []
                     )
                 }

--- a/native/Tests/OscilloCoreTests/AppBundleMetadataTests.swift
+++ b/native/Tests/OscilloCoreTests/AppBundleMetadataTests.swift
@@ -15,8 +15,8 @@ final class AppBundleMetadataTests: XCTestCase {
         XCTAssertEqual(plist["CFBundleExecutable"] as? String, "OscilloMac")
         XCTAssertEqual(plist["CFBundlePackageType"] as? String, "APPL")
         XCTAssertEqual(plist["CFBundleIdentifier"] as? String, "com.zachyzissou.oscillo.native.mac")
-        XCTAssertEqual(plist["CFBundleShortVersionString"] as? String, "0.1.9")
-        XCTAssertEqual(plist["CFBundleVersion"] as? String, "10")
+        XCTAssertEqual(plist["CFBundleShortVersionString"] as? String, "0.2.0")
+        XCTAssertEqual(plist["CFBundleVersion"] as? String, "11")
         XCTAssertEqual(
             plist["NSMicrophoneUsageDescription"] as? String,
             "Oscillo uses microphone input to drive real-time audio-reactive visuals."

--- a/native/Tests/OscilloCoreTests/PerformanceCommandTests.swift
+++ b/native/Tests/OscilloCoreTests/PerformanceCommandTests.swift
@@ -1,0 +1,26 @@
+import XCTest
+@testable import OscilloCore
+
+final class PerformanceCommandTests: XCTestCase {
+    func testTransportCommandShortcutsAreStable() {
+        XCTAssertEqual(PerformanceCommand.togglePreview.keyEquivalent, " ")
+        XCTAssertEqual(PerformanceCommand.toggleMicrophone.keyEquivalent, "m")
+    }
+
+    func testSceneShortcutOrderMatchesSceneOrder() {
+        let keys = SceneMode.allCases.map(\.performanceKey)
+
+        XCTAssertEqual(keys, ["1", "2", "3", "4", "5"])
+    }
+
+    func testPresetShortcutOrderMatchesPerformanceRail() {
+        let keys = PerformancePreset.allCases.map(\.performanceKey)
+
+        XCTAssertEqual(keys, ["q", "w", "e", "r"])
+    }
+
+    func testCommandTitlesUseVisibleLabels() {
+        XCTAssertEqual(PerformanceCommand.scene(.liquidSurface).title, "Liquid Surface")
+        XCTAssertEqual(PerformanceCommand.preset(.surge).title, "Surge")
+    }
+}

--- a/native/Tests/OscilloCoreTests/PerformanceCommandTests.swift
+++ b/native/Tests/OscilloCoreTests/PerformanceCommandTests.swift
@@ -3,18 +3,18 @@ import XCTest
 
 final class PerformanceCommandTests: XCTestCase {
     func testTransportCommandShortcutsAreStable() {
-        XCTAssertEqual(PerformanceCommand.togglePreview.keyEquivalent, " ")
-        XCTAssertEqual(PerformanceCommand.toggleMicrophone.keyEquivalent, "m")
+        XCTAssertEqual(String(PerformanceCommand.togglePreview.keyEquivalent), " ")
+        XCTAssertEqual(String(PerformanceCommand.toggleMicrophone.keyEquivalent), "m")
     }
 
     func testSceneShortcutOrderMatchesSceneOrder() {
-        let keys = SceneMode.allCases.map(\.performanceKey)
+        let keys = SceneMode.allCases.map { String($0.performanceKey) }
 
         XCTAssertEqual(keys, ["1", "2", "3", "4", "5"])
     }
 
     func testPresetShortcutOrderMatchesPerformanceRail() {
-        let keys = PerformancePreset.allCases.map(\.performanceKey)
+        let keys = PerformancePreset.allCases.map { String($0.performanceKey) }
 
         XCTAssertEqual(keys, ["q", "w", "e", "r"])
     }


### PR DESCRIPTION
## Summary\n- add shared performance command metadata for preview, mic, scenes, and presets\n- add native macOS Perform menu shortcuts: Space, M, 1-5, and QWER\n- reuse the same audio/controller actions as the rail\n- bump native app metadata to 0.2.0 build 11\n\nCloses #442\n\n## Verification\n- DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer swift test\n- DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer CONFIGURATION=release ./Scripts/build-macos-app.sh\n- codesign --verify --deep --strict --verbose=1 native/dist/Oscillo.app\n- plutil -p native/dist/Oscillo.app/Contents/Info.plist | rg 'CFBundleShortVersionString|CFBundleVersion'\n- bash native/Scripts/check-no-secrets.sh\n- osascript menu inspection confirmed Perform menu items\n- local shortcut smoke: q applied Drift values, 2 switched to Tunnel\n- local screenshot: /tmp/oscillo-0.2.0-keyboard-local.png