### PR TITLE
feat(native): add audio calibration controls

### DIFF
--- a/native/AppBundle/Info.plist
+++ b/native/AppBundle/Info.plist
@@ -17,9 +17,9 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>0.2.0</string>
+	<string>0.2.1</string>
 	<key>CFBundleVersion</key>
-	<string>11</string>
+	<string>12</string>
 	<key>LSApplicationCategoryType</key>
 	<string>public.app-category.music</string>
 	<key>LSMinimumSystemVersion</key>

--- a/native/Sources/OscilloCore/AudioCalibration.swift
+++ b/native/Sources/OscilloCore/AudioCalibration.swift
@@ -1,39 +1,39 @@
 import Foundation
+import os
 
 public struct AudioCalibration: Equatable, Sendable {
-    public var sensitivity: Float
-    public var noiseFloor: Float
+    private static let sensitivityRange: ClosedRange<Float> = 0.25...3.0
+    private static let noiseFloorRange: ClosedRange<Float> = 0.0...0.45
+
+    public let sensitivity: Float
+    public let noiseFloor: Float
 
     public init(
         sensitivity: Float = 1.0,
         noiseFloor: Float = 0.03
     ) {
-        self.sensitivity = sensitivity.clamped(to: 0.25...3.0)
-        self.noiseFloor = noiseFloor.clamped(to: 0.0...0.45)
+        self.sensitivity = sensitivity.clamped(to: Self.sensitivityRange)
+        self.noiseFloor = noiseFloor.clamped(to: Self.noiseFloorRange)
     }
 
     public static let standard = AudioCalibration()
 }
 
 public final class AudioCalibrationStore: @unchecked Sendable {
-    private let lock = NSLock()
-    private var currentCalibration: AudioCalibration
+    private let calibration: OSAllocatedUnfairLock<AudioCalibration>
 
     public init(initialCalibration: AudioCalibration = .standard) {
-        self.currentCalibration = initialCalibration
+        self.calibration = OSAllocatedUnfairLock(initialState: initialCalibration)
     }
 
     public func update(_ calibration: AudioCalibration) {
-        lock.lock()
-        currentCalibration = calibration
-        lock.unlock()
+        self.calibration.withLock { currentCalibration in
+            currentCalibration = calibration
+        }
     }
 
     public func snapshot() -> AudioCalibration {
-        lock.lock()
-        let calibration = currentCalibration
-        lock.unlock()
-        return calibration
+        calibration.withLock { $0 }
     }
 }
 

--- a/native/Sources/OscilloCore/AudioCalibration.swift
+++ b/native/Sources/OscilloCore/AudioCalibration.swift
@@ -1,0 +1,75 @@
+import Foundation
+
+public struct AudioCalibration: Equatable, Sendable {
+    public var sensitivity: Float
+    public var noiseFloor: Float
+
+    public init(
+        sensitivity: Float = 1.0,
+        noiseFloor: Float = 0.03
+    ) {
+        self.sensitivity = sensitivity.clamped(to: 0.25...3.0)
+        self.noiseFloor = noiseFloor.clamped(to: 0.0...0.45)
+    }
+
+    public static let standard = AudioCalibration()
+}
+
+public final class AudioCalibrationStore: @unchecked Sendable {
+    private let lock = NSLock()
+    private var currentCalibration: AudioCalibration
+
+    public init(initialCalibration: AudioCalibration = .standard) {
+        self.currentCalibration = initialCalibration
+    }
+
+    public func update(_ calibration: AudioCalibration) {
+        lock.lock()
+        currentCalibration = calibration
+        lock.unlock()
+    }
+
+    public func snapshot() -> AudioCalibration {
+        lock.lock()
+        let calibration = currentCalibration
+        lock.unlock()
+        return calibration
+    }
+}
+
+public enum AudioFeatureCalibrator {
+    public static func apply(
+        _ features: AudioFeatures,
+        calibration: AudioCalibration
+    ) -> AudioFeatures {
+        AudioFeatures(
+            volume: calibrated(features.volume, calibration: calibration),
+            bands: AudioEnergyBands(
+                bass: calibrated(features.bassEnergy, calibration: calibration),
+                mid: calibrated(features.midEnergy, calibration: calibration),
+                treble: calibrated(features.trebleEnergy, calibration: calibration)
+            ),
+            peakFrequency: features.peakFrequency,
+            spectralCentroid: features.spectralCentroid,
+            rms: calibrated(features.rms, calibration: calibration),
+            zeroCrossingRate: features.zeroCrossingRate
+        )
+    }
+
+    private static func calibrated(
+        _ value: Float,
+        calibration: AudioCalibration
+    ) -> Float {
+        guard value > calibration.noiseFloor else { return 0 }
+
+        let usableRange = max(0.0001, 1.0 - calibration.noiseFloor)
+        let normalized = (value - calibration.noiseFloor) / usableRange
+        return (normalized * calibration.sensitivity).clamped(to: 0...1)
+    }
+}
+
+private extension Float {
+    func clamped(to range: ClosedRange<Float>) -> Float {
+        min(max(self, range.lowerBound), range.upperBound)
+    }
+}

--- a/native/Sources/OscilloCore/AudioFeatureStore.swift
+++ b/native/Sources/OscilloCore/AudioFeatureStore.swift
@@ -1,23 +1,19 @@
-import Foundation
+import os
 
 public final class AudioFeatureStore: @unchecked Sendable {
-    private let lock = NSLock()
-    private var currentFeatures = AudioFeatures.silence
+    private let features = OSAllocatedUnfairLock(initialState: AudioFeatures.silence)
 
     public init() {
         // Public initializer exposes the store outside the module.
     }
 
     public func update(_ features: AudioFeatures) {
-        lock.lock()
-        currentFeatures = features
-        lock.unlock()
+        self.features.withLock { currentFeatures in
+            currentFeatures = features
+        }
     }
 
     public func snapshot() -> AudioFeatures {
-        lock.lock()
-        let features = currentFeatures
-        lock.unlock()
-        return features
+        features.withLock { $0 }
     }
 }

--- a/native/Sources/OscilloMac/ContentView.swift
+++ b/native/Sources/OscilloMac/ContentView.swift
@@ -144,6 +144,8 @@ private struct InstrumentSpine: View {
 
                 SignalReadoutModule(audioEngine: audioEngine)
 
+                CalibrationRackModule(audioEngine: audioEngine)
+
                 VStack(alignment: .leading, spacing: 8) {
                     ModuleLabel("PERFORM")
                     LazyVGrid(columns: [
@@ -257,6 +259,48 @@ private struct SignalReadoutModule: View {
                 RailMeter(title: "BASS", value: audioEngine.features.bassEnergy, accent: SignalTheme.signalTeal)
                 RailMeter(title: "MID", value: audioEngine.features.midEnergy, accent: SignalTheme.oscillatorCyan)
                 RailMeter(title: "HI", value: audioEngine.features.trebleEnergy, accent: SignalTheme.warmPeak)
+            }
+        }
+    }
+}
+
+private struct CalibrationRackModule: View {
+    @ObservedObject var audioEngine: LiveAudioEngine
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            HStack(alignment: .firstTextBaseline) {
+                ModuleLabel("CALIBRATE")
+                Spacer(minLength: 10)
+                SignalBadge("INPUT")
+            }
+
+            SignalSlider(
+                title: "SENS",
+                value: Binding(
+                    get: { audioEngine.calibration.sensitivity },
+                    set: { audioEngine.setSensitivity($0) }
+                ),
+                range: 0.25...3.0,
+                accent: SignalTheme.signalTeal
+            )
+
+            SignalSlider(
+                title: "GATE",
+                value: Binding(
+                    get: { audioEngine.calibration.noiseFloor },
+                    set: { audioEngine.setNoiseFloor($0) }
+                ),
+                range: 0.0...0.45,
+                accent: SignalTheme.warmPeak
+            )
+
+            SignalActionButton(
+                title: "RESET",
+                systemImage: "dial.low",
+                isActive: false
+            ) {
+                audioEngine.resetCalibration()
             }
         }
     }

--- a/native/Sources/OscilloMac/ContentView.swift
+++ b/native/Sources/OscilloMac/ContentView.swift
@@ -282,7 +282,8 @@ private struct CalibrationRackModule: View {
                     set: { audioEngine.setSensitivity($0) }
                 ),
                 range: 0.25...3.0,
-                accent: SignalTheme.signalTeal
+                accent: SignalTheme.signalTeal,
+                accessibilityLabel: "Sensitivity"
             )
 
             SignalSlider(
@@ -292,7 +293,8 @@ private struct CalibrationRackModule: View {
                     set: { audioEngine.setNoiseFloor($0) }
                 ),
                 range: 0.0...0.45,
-                accent: SignalTheme.warmPeak
+                accent: SignalTheme.warmPeak,
+                accessibilityLabel: "Noise gate"
             )
 
             SignalActionButton(
@@ -311,6 +313,7 @@ private struct SignalSlider: View {
     @Binding var value: Float
     let range: ClosedRange<Float>
     let accent: Color
+    var accessibilityLabel: String?
 
     var body: some View {
         VStack(alignment: .leading, spacing: 6) {
@@ -345,6 +348,8 @@ private struct SignalSlider: View {
             )
             .controlSize(.small)
             .tint(accent)
+            .accessibilityLabel(Text(accessibilityLabel ?? title))
+            .accessibilityValue(Text(value.formatted(.number.precision(.fractionLength(2)))))
         }
     }
 

--- a/native/Sources/OscilloMac/LiveAudioEngine.swift
+++ b/native/Sources/OscilloMac/LiveAudioEngine.swift
@@ -7,11 +7,13 @@ final class LiveAudioEngine: ObservableObject {
     @Published private(set) var isRunning = false
     @Published private(set) var isPreviewing = false
     @Published private(set) var features = AudioFeatures.silence
+    @Published private(set) var calibration = AudioCalibration.standard
     @Published private(set) var statusMessage = "Preview signal"
 
     let featureStore = AudioFeatureStore()
 
     private let sceneSettingsStore: SceneSettingsStore
+    private let calibrationStore = AudioCalibrationStore()
     private let engine = AVAudioEngine()
     private let processor = AudioProcessor()
     private var previewTimer: Timer?
@@ -36,12 +38,16 @@ final class LiveAudioEngine: ObservableObject {
         let format = input.outputFormat(forBus: 0)
         let processor = processor
         let featureStore = featureStore
+        let calibrationStore = calibrationStore
 
         input.installTap(onBus: 0, bufferSize: 1_024, format: format) { buffer, _ in
             guard let features = processor.process(buffer: buffer) else {
                 return
             }
-            featureStore.update(features)
+            featureStore.update(AudioFeatureCalibrator.apply(
+                features,
+                calibration: calibrationStore.snapshot()
+            ))
         }
 
         do {
@@ -111,6 +117,27 @@ final class LiveAudioEngine: ObservableObject {
         }
     }
 
+    func setSensitivity(_ value: Float) {
+        updateCalibration(
+            sensitivity: value,
+            noiseFloor: calibration.noiseFloor
+        )
+    }
+
+    func setNoiseFloor(_ value: Float) {
+        updateCalibration(
+            sensitivity: calibration.sensitivity,
+            noiseFloor: value
+        )
+    }
+
+    func resetCalibration() {
+        updateCalibration(
+            sensitivity: AudioCalibration.standard.sensitivity,
+            noiseFloor: AudioCalibration.standard.noiseFloor
+        )
+    }
+
     private func beginPublishing() {
         guard publishTimer == nil else { return }
 
@@ -139,14 +166,28 @@ final class LiveAudioEngine: ObservableObject {
         let treble = normalizedWave(previewPhase * 2.6 + 2.0) * 0.48
         let volume = min(1, 0.28 + bass * 0.44 + treble * 0.18)
 
-        featureStore.update(AudioFeatures(
+        let rawFeatures = AudioFeatures(
             volume: volume,
             bands: AudioEnergyBands(bass: bass, mid: mid, treble: treble),
             peakFrequency: 120 + mid * 2_800,
             spectralCentroid: 600 + treble * 7_500,
             rms: volume,
             zeroCrossingRate: 0.04 + treble * 0.16
+        )
+
+        featureStore.update(AudioFeatureCalibrator.apply(
+            rawFeatures,
+            calibration: calibrationStore.snapshot()
         ))
+    }
+
+    private func updateCalibration(sensitivity: Float, noiseFloor: Float) {
+        let next = AudioCalibration(
+            sensitivity: sensitivity,
+            noiseFloor: noiseFloor
+        )
+        calibration = next
+        calibrationStore.update(next)
     }
 
     private func normalizedWave(_ phase: Float) -> Float {

--- a/native/Tests/OscilloCoreTests/AppBundleMetadataTests.swift
+++ b/native/Tests/OscilloCoreTests/AppBundleMetadataTests.swift
@@ -15,8 +15,8 @@ final class AppBundleMetadataTests: XCTestCase {
         XCTAssertEqual(plist["CFBundleExecutable"] as? String, "OscilloMac")
         XCTAssertEqual(plist["CFBundlePackageType"] as? String, "APPL")
         XCTAssertEqual(plist["CFBundleIdentifier"] as? String, "com.zachyzissou.oscillo.native.mac")
-        XCTAssertEqual(plist["CFBundleShortVersionString"] as? String, "0.2.0")
-        XCTAssertEqual(plist["CFBundleVersion"] as? String, "11")
+        XCTAssertEqual(plist["CFBundleShortVersionString"] as? String, "0.2.1")
+        XCTAssertEqual(plist["CFBundleVersion"] as? String, "12")
         XCTAssertEqual(
             plist["NSMicrophoneUsageDescription"] as? String,
             "Oscillo uses microphone input to drive real-time audio-reactive visuals."

--- a/native/Tests/OscilloCoreTests/AudioCalibrationTests.swift
+++ b/native/Tests/OscilloCoreTests/AudioCalibrationTests.swift
@@ -1,0 +1,52 @@
+import XCTest
+@testable import OscilloCore
+
+final class AudioCalibrationTests: XCTestCase {
+    func testClampsCalibrationControlsToSupportedRanges() {
+        let calibration = AudioCalibration(
+            sensitivity: 9,
+            noiseFloor: -1
+        )
+
+        XCTAssertEqual(calibration.sensitivity, 3.0)
+        XCTAssertEqual(calibration.noiseFloor, 0.0)
+
+        let upperFloor = AudioCalibration(noiseFloor: 1)
+        XCTAssertEqual(upperFloor.noiseFloor, 0.45)
+    }
+
+    func testStorePublishesThreadSafeSnapshots() {
+        let store = AudioCalibrationStore()
+        store.update(AudioCalibration(sensitivity: 1.5, noiseFloor: 0.12))
+
+        let snapshot = store.snapshot()
+
+        XCTAssertEqual(snapshot.sensitivity, 1.5)
+        XCTAssertEqual(snapshot.noiseFloor, 0.12)
+    }
+
+    func testCalibratorAppliesNoiseFloorAndSensitivity() {
+        let features = AudioFeatures(
+            volume: 0.2,
+            bands: AudioEnergyBands(bass: 0.1, mid: 0.5, treble: 0.8),
+            peakFrequency: 440,
+            spectralCentroid: 1_200,
+            rms: 0.2,
+            zeroCrossingRate: 0.04
+        )
+
+        let calibrated = AudioFeatureCalibrator.apply(
+            features,
+            calibration: AudioCalibration(sensitivity: 2.0, noiseFloor: 0.1)
+        )
+
+        XCTAssertEqual(calibrated.volume, 0.2222, accuracy: 0.0001)
+        XCTAssertEqual(calibrated.bassEnergy, 0)
+        XCTAssertEqual(calibrated.midEnergy, 0.8889, accuracy: 0.0001)
+        XCTAssertEqual(calibrated.trebleEnergy, 1.0)
+        XCTAssertEqual(calibrated.rms, 0.2222, accuracy: 0.0001)
+        XCTAssertEqual(calibrated.peakFrequency, 440)
+        XCTAssertEqual(calibrated.spectralCentroid, 1_200)
+        XCTAssertEqual(calibrated.zeroCrossingRate, 0.04)
+    }
+}


### PR DESCRIPTION
## Summary
- add shared `AudioCalibration`, thread-safe store, and calibrator tests for sensitivity/noise-floor gating
- apply calibration to microphone and preview feature updates before the Metal renderer consumes them
- add compact CALIBRATE controls to the native macOS rail and bump the app to 0.2.1 build 12

Closes #444.

## Verification
- `DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer swift test`
- `git diff --check`
- `bash native/Scripts/check-no-secrets.sh`
- `DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer CONFIGURATION=release ./Scripts/build-macos-app.sh`
- `codesign --verify --deep --strict --verbose=1 native/dist/Oscillo.app`
- local screenshot: `/tmp/oscillo-0.2.1-calibration-local.png`

## Release
- Target tag after merge: `native-v0.2.1`
